### PR TITLE
[TOOLS-1075] blocks initialization when Jira Plugin not installed

### DIFF
--- a/src/main/java/objective/taskboard/jira/CustomJiraPluginInstalledVerifier.java
+++ b/src/main/java/objective/taskboard/jira/CustomJiraPluginInstalledVerifier.java
@@ -8,6 +8,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 
@@ -42,6 +44,12 @@ public class CustomJiraPluginInstalledVerifier {
 
         if (response.getStatus() != 404)
             return;
+
+        boolean htmlResponse = response.getHeaders().stream()
+                .filter(h -> HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(h.getName()))
+                .anyMatch(h -> h.getValue().contains("text/html"));
+        if(htmlResponse)
+            throw new CustomJiraPluginNotInstalledException();
 
         try (InputStream body = response.getBody().in()) {
             String content = IOUtilities.resourceAsString(body);

--- a/src/main/java/objective/taskboard/jira/CustomJiraPluginNotInstalledFailureAnalyzer.java
+++ b/src/main/java/objective/taskboard/jira/CustomJiraPluginNotInstalledFailureAnalyzer.java
@@ -1,0 +1,16 @@
+package objective.taskboard.jira;
+
+import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+
+public class CustomJiraPluginNotInstalledFailureAnalyzer
+        extends AbstractFailureAnalyzer<CustomJiraPluginInstalledVerifier.CustomJiraPluginNotInstalledException> {
+
+    @Override
+    protected FailureAnalysis analyze(Throwable rootFailure
+            , CustomJiraPluginInstalledVerifier.CustomJiraPluginNotInstalledException cause) {
+        String description = "Could not retrieve response from Jira Plugin REST endpoint";
+        String action = "Verify if the Jira Plugin is installed correctly";
+        return new FailureAnalysis(description, action, cause);
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.diagnostics.FailureAnalyzer=\
+objective.taskboard.jira.CustomJiraPluginNotInstalledFailureAnalyzer


### PR DESCRIPTION
On initialization, tests if Jira has the Jira Plugin installed,
otherwise stops taskboard initialization with the following mesasge:

***************************
APPLICATION FAILED TO START
***************************

Description:

Could not retrieve response from Jira Plugin REST endpoint

Action:

Verify if the Jira Plugin is installed correctly