### PR TITLE
[TOOLS-1311] Bugfix: Card Field Filter by Team changed

### DIFF
--- a/src/test/java/objective/taskboard/data/CardFieldFilterTest.java
+++ b/src/test/java/objective/taskboard/data/CardFieldFilterTest.java
@@ -1,5 +1,6 @@
 package objective.taskboard.data;
 
+import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toSet;
 import static objective.taskboard.filterPreferences.CardFieldFilterUtils.ISSUE_TYPE_1_VALUE;
 import static objective.taskboard.filterPreferences.CardFieldFilterUtils.PROJECT_1_VALUE;
@@ -14,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.stream.Stream;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -87,19 +88,11 @@ public class CardFieldFilterTest {
     }
 
     @Test
-    public void fieldSelectorTeam_givenAllValuesSelected_whenIssueHasARegisteredTeam_thenIsSelected() {
+    public void fieldSelectorTeam_givenAllValuesSelected_whenIssueHasAVisibleTeam_thenIsSelected() {
         subject = new CardFieldFilter(FieldSelector.TEAM, teamFilterFieldsValuesAllSelected());
 
-        boolean isSelected = subject.isIssueSelected(issueMock(null, null, TEAM_1_VALUE));
+        boolean isSelected = subject.isIssueSelected(issueMock(null, null, asList(TEAM_1_VALUE)));
         assertEquals(true, isSelected);
-    }
-
-    @Test
-    public void fieldSelectorTeam_givenAllValuesSelected_whenIssueHasANotRegisteredTeam_thenIsNotSelected() {
-        subject = new CardFieldFilter(FieldSelector.TEAM, teamFilterFieldsValuesAllSelected());
-
-        boolean isSelected = subject.isIssueSelected(issueMock(null, null, VALUE_NOT_REGISTERED));
-        assertEquals(false, isSelected);
     }
 
     @Test
@@ -111,18 +104,52 @@ public class CardFieldFilterTest {
         FilterFieldValue filterValueToDeselect = getFilterFieldValue(subject, TEAM_NOT_SELECTED);
         filterValueToDeselect.setSelected(false);
 
-        boolean isSelected = subject.isIssueSelected(issueMock(null, null, TEAM_NOT_SELECTED));
+        boolean isSelected = subject.isIssueSelected(issueMock(null, null, asList(TEAM_NOT_SELECTED)));
         assertEquals(false, isSelected);
     }
 
-    private Issue issueMock(String projectKey, String type, String team) {
+    @Test
+    public void fieldSelectorTeam_givenAllValuesSelected_whenIssueHasOnlyInvisibleTeams_thenIsSelected() {
+        final String TEAM_INVISIBLE = VALUE_NOT_REGISTERED;
+
+        subject = new CardFieldFilter(FieldSelector.TEAM, teamFilterFieldsValuesAllSelected());
+
+        boolean isSelected = subject.isIssueSelected(issueMock(null, null, asList(TEAM_INVISIBLE)));
+        assertEquals(true, isSelected);
+    }
+
+    @Test
+    public void fieldSelectorTeam_givenAllValuesSelected_whenIssueHasInvisibleAndVisibleTeams_thenIsSelected() {
+        final String TEAM_INVISIBLE = VALUE_NOT_REGISTERED;
+
+        subject = new CardFieldFilter(FieldSelector.TEAM, teamFilterFieldsValuesAllSelected());
+
+        boolean isSelected = subject.isIssueSelected(issueMock(null, null, asList(TEAM_INVISIBLE, TEAM_1_VALUE)));
+        assertEquals(true, isSelected);
+    }
+
+    @Test
+    public void fieldSelectorTeam_givenOneTeamValueNotSelected_whenIssueHasThisTeamAndAInvisibleTeam_thenIsNotSelected() {
+        final String TEAM_NOT_SELECTED = TEAM_1_VALUE;
+        final String TEAM_INVISIBLE = VALUE_NOT_REGISTERED;
+
+        subject = new CardFieldFilter(FieldSelector.TEAM, teamFilterFieldsValuesAllSelected());
+
+        FilterFieldValue filterValueToDeselect = getFilterFieldValue(subject, TEAM_NOT_SELECTED);
+        filterValueToDeselect.setSelected(false);
+
+        boolean isSelected = subject.isIssueSelected(issueMock(null, null, asList(TEAM_NOT_SELECTED, TEAM_INVISIBLE)));
+        assertEquals(false, isSelected);
+    }
+
+    private Issue issueMock(String projectKey, String type, List<String> teams) {
         Issue issue = mock(Issue.class);
         if (!isEmpty(projectKey))
             when(issue.getProjectKey()).thenReturn(projectKey);
         if (!isEmpty(type))
             when(issue.getType()).thenReturn(Long.valueOf(type));
-        if (!isEmpty(team))
-            when(issue.getTeams()).thenReturn(Stream.of(team).map(teamName -> new CardTeam(teamName, 0L)).collect(toSet()));
+        if (teams != null)
+            when(issue.getTeams()).thenReturn(teams.stream().map(teamName -> new CardTeam(teamName, 0L)).collect(toSet()));
         return issue;
     }
 


### PR DESCRIPTION
- When an issue has only invisible teams to the user, that issue must be selected.
- When an issue has invisible and visible teams to the user, if those visible teams aren't selected, then that issue isn't selected.