### PR TITLE
[TOOLS-1688] WIP and Througput charts weekly basis

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "moment": "^2.20.1",
     "jquery.maskedinput": "^1.4.1",
     "jquery-file-download": "^1.4.6",
-    "dom-to-image": "^2.6.0"
+    "dom-to-image": "^2.6.0",
+    "highcharts": "^6.1.3"
   },
   "devDependencies": {
     "web-component-tester": "^5.0.1"

--- a/src/main/java/objective/taskboard/followup/WeekRangeNormalizer.java
+++ b/src/main/java/objective/taskboard/followup/WeekRangeNormalizer.java
@@ -1,0 +1,34 @@
+package objective.taskboard.followup;
+
+import java.time.DayOfWeek;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAdjusters;
+
+import org.apache.commons.lang3.Range;
+
+import objective.taskboard.utils.DateTimeUtils;
+
+public class WeekRangeNormalizer {
+
+    public static Range<ZonedDateTime> normalizeWeekRange(FollowUpTimeline timeline, Range<ZonedDateTime> dataSetDateRange, ZoneId zone) {
+        ZonedDateTime baseStartDate = timeline.getStart().map(d -> d.atStartOfDay(zone)).orElse(dataSetDateRange.getMinimum());
+        ZonedDateTime baseEndDate = timeline.getEnd().map(d -> d.atStartOfDay(zone)).orElse(dataSetDateRange.getMaximum());
+        
+        if (baseStartDate.isAfter(baseEndDate))
+            throw new IllegalArgumentException("Start date is after end date!");
+
+        ZonedDateTime normalizedStartDate = findPreviousSunday(baseStartDate);
+        ZonedDateTime normalizedEndDate = findNextSaturday(baseEndDate);
+        
+        return DateTimeUtils.range(normalizedStartDate, normalizedEndDate);
+    }
+
+    private static ZonedDateTime findNextSaturday(ZonedDateTime baseEndDate) {
+        return baseEndDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+    }
+
+    private static ZonedDateTime findPreviousSunday(ZonedDateTime baseStartDate) {
+        return baseStartDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+    }
+}

--- a/src/main/java/objective/taskboard/followup/WipKPIDataProvider.java
+++ b/src/main/java/objective/taskboard/followup/WipKPIDataProvider.java
@@ -2,15 +2,24 @@ package objective.taskboard.followup;
 
 import static org.springframework.util.CollectionUtils.isEmpty;
 
+import java.time.DayOfWeek;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import org.apache.commons.lang3.Range;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
 
 import objective.taskboard.followup.kpi.WipChartDataSet;
 import objective.taskboard.followup.kpi.WipDataPoint;
@@ -18,47 +27,60 @@ import objective.taskboard.followup.kpi.WipKPIService;
 import objective.taskboard.utils.DateTimeUtils;
 
 @Component
-public class WipKPIDataProvider extends KPIByLevelDataProvider<WipChartDataSet,WipDataSet> {
+public class WipKPIDataProvider extends KPIByLevelDataProvider<WipChartDataSet, WipDataSet> {
 
     @Autowired
     private WipKPIService wipService;
-    
+
+
     @Override
     protected WipChartDataSet transform(List<WipDataSet> wipDatas, FollowUpTimeline timeline, ZoneId timezone) {
-        
-        final List<WipDataPoint> rowsFilteredByTimeline = new LinkedList<>();
-        for (int i = 0; i < wipDatas.size(); ++i) {
-            
-            WipDataSet ds = wipDatas.get(i);
 
-            if(isEmpty(ds.rows))
+        final List<WipDataPoint> rowsFilteredByTimeline = new LinkedList<>();
+        for (WipDataSet ds : wipDatas) {
+
+            if (isEmpty(ds.rows))
                 continue;
 
-            Range<ZonedDateTime> dateRange = getDateRange(timeline, ds, timezone);
-            rowsFilteredByTimeline.addAll(ds.rows.stream()
-                    .filter(row -> dateRange.contains(row.date))
-                    .map(row -> new WipDataPoint(row.date, row.type, row.status, row.count))
-                    .collect(Collectors.toList()));
+            final ZonedDateTime dsStartDate = ds.rows.get(0).date;
+            final ZonedDateTime dsEndDate = ds.rows.get(ds.rows.size() - 1).date;
+            final Range<ZonedDateTime> dataSetDateRange = DateTimeUtils.range(dsStartDate, dsEndDate);
+
+            final Range<ZonedDateTime> resultDateRange = WeekRangeNormalizer.normalizeWeekRange(timeline,
+                    dataSetDateRange, timezone);
+
+            final Map<ZonedDateTime, List<WipRow>> filteredRows = ds.rows.stream()
+                    .filter(row -> resultDateRange.contains(row.date))
+                    .collect(Collectors.groupingBy(
+                            row -> row.date.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)),
+                            LinkedHashMap::new, Collectors.toList()));
+
+            filteredRows.forEach((sunday, rowsByWeek) -> {
+                Table<String, String, LongStream> weekWipByTypeAndStatus = rowsByWeek.stream()
+                        .collect(Tables.toTable(
+                                row -> row.type, 
+                                row -> row.status, 
+                                row -> LongStream.of(row.count), 
+                                LongStream::concat, 
+                                HashBasedTable::create));
+
+                rowsFilteredByTimeline.addAll(
+                        weekWipByTypeAndStatus.cellSet().stream()
+                                .map(cell -> 
+                                    new WipDataPoint(
+                                        sunday, 
+                                        cell.getRowKey(), 
+                                        cell.getColumnKey(), 
+                                        cell.getValue().average().orElse(0.0)))
+                                .collect(Collectors.toList()));
+            });
         }
 
         return new WipChartDataSet(rowsFilteredByTimeline);
     }
-    
+
     @Override
     protected List<WipDataSet> getDataSets(FollowUpData followupData) {
         return wipService.getData(followupData);
     }
-
-    private Range<ZonedDateTime> getDateRange(FollowUpTimeline timeline, WipDataSet ds, ZoneId timezone) {
-        ZonedDateTime startDate = timeline.getStart()
-                .map(d -> d.atStartOfDay(timezone))
-                .orElseGet(() -> ds.rows.get(0).date);
-
-        ZonedDateTime endDate = timeline.getEnd()
-                .map(d -> d.atStartOfDay(timezone))
-                .orElseGet(() -> ds.rows.get(ds.rows.size()-1).date);
-
-        return DateTimeUtils.range(startDate, endDate);
-    }
-
 }

--- a/src/main/java/objective/taskboard/followup/kpi/WipDataPoint.java
+++ b/src/main/java/objective/taskboard/followup/kpi/WipDataPoint.java
@@ -5,14 +5,14 @@ import java.util.Date;
 
 public class WipDataPoint {
     public final Date date;
-    public final String type;
-    public final String status;
-    public final Long count;
+    public final String issueType;
+    public final String issueStatus;
+    public final double average;
 
-    public WipDataPoint(ZonedDateTime date, String type, String status, Long count) {
+    public WipDataPoint(ZonedDateTime date, String type, String status, double average) {
         this.date = Date.from(date.toInstant());
-        this.type = type;
-        this.status = status;
-        this.count = count;
+        this.issueType = type;
+        this.issueStatus = status;
+        this.average = average;
     }
 }

--- a/src/main/resources/liferay-uat-properties/application-dev.properties
+++ b/src/main/resources/liferay-uat-properties/application-dev.properties
@@ -1,0 +1,436 @@
+#THYMELEAF
+spring.thymeleaf.cache=false
+
+spring.jpa.show-sql=false
+
+#LOGGING
+logging.level.objective.taskboard=DEBUG
+
+#########################
+##### TASKBOARD #########
+#########################
+
+spring.profiles.active=liferay
+
+#THYMELEAF
+spring.thymeleaf.cache=false
+
+#SECURITY
+security.ignored=/static/**
+spring.mvc.static-path-pattern=/static/**
+security.basic.enabled:false
+#logging.level.org.springframework.security:INFO
+logging.level.org.springframework.security:ERROR
+#logging.level.org.springframework.boot.actuate.audit.listener.AuditListener:DEBUG
+logging.level.org.springframework.boot.actuate.audit.listener.AuditListener:ERROR
+
+#JIRA
+jira.url=http://10.44.3.170
+jira.lousa.username=gs-task-board
+jira.lousa.password=r3m3mb3r
+
+jira.customfield.t-shirt-size.ids=customfield_10117,customfield_10110,customfield_10118,customfield_10119,customfield_10109,customfield_10105,customfield_10111,customfield_10113,customfield_10106,customfield_10115,customfield_10108,customfield_10201
+jira.customfield.class-of-service.id=customfield_10107
+jira.customfield.blocked.id=customfield_10102
+jira.customfield.blocked.yes-option-id=10100
+jira.customfield.last-block-reason.id=customfield_10122
+jira.customfield.co-assignees.id=customfield_10104
+
+jira.customfield.class-of-service.colors.0=#EEEEEE
+jira.customfield.class-of-service.colors.10112=#EEEEEE
+jira.customfield.class-of-service.colors.10113=#FEE5BC
+jira.customfield.class-of-service.colors.10114=#FF8B94
+jira.customfield.class-of-service.colors.10115=#ADD9FE
+jira.customfield.additional-estimated-hours.id=customfield_10101
+jira.customfield.release.id=customfield_10125
+jira.customfield.assigned-teams.id=customfield_10300
+
+jira.issuelink.dependencies=Depends,Root Cause
+jira.issuelink.demand-id=10301
+
+jira.issuetype.demand.id=10103
+jira.issuetype.default-feature.id=10104
+
+jira.issuetype.features[0].id=10004
+jira.issuetype.features[0].name=Bug
+jira.issuetype.features[1].id=10002
+jira.issuetype.features[1].name=Task
+jira.issuetype.features[2].id=10104
+jira.issuetype.features[2].name=Feature
+
+#Sub-task, Alpha bug, Alpha test, Backend Development, Feature Planning, Feature Review, Frontend Development, QA, Tech Planning, UAT, UX, Functional Test
+jira.issuetype.subtasks[0].id=10003
+jira.issuetype.subtasks[1].id=10100
+jira.issuetype.subtasks[2].id=10101
+jira.issuetype.subtasks[3].id=10102
+jira.issuetype.subtasks[4].id=10105
+jira.issuetype.subtasks[5].id=10106
+jira.issuetype.subtasks[6].id=10107
+jira.issuetype.subtasks[7].id=10108
+jira.issuetype.subtasks[8].id=10110
+jira.issuetype.subtasks[9].id=10111
+jira.issuetype.subtasks[10].id=10112
+jira.issuetype.subtasks[11].id=10115
+
+jira.statuses-canceled-ids=10101
+jira.statuses-completed-ids=10001
+jira.statuses-deferred-ids=10102
+
+jira.transitions-done-names=,
+jira.transitions-cancel-names=,
+jira.transitions-with-required-comment-names=,
+
+jira.resolutions.done.name=,
+jira.resolutions.canceled.name=,
+
+#DATABASE
+spring.datasource.driverClassName=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://10.44.10.202:3306/taskboard_lf_uat_dev?useUnicode=true&characterEncoding=UTF8&sessionVariables=storage_engine=InnoDB&zeroDateTimeBehavior=convertToNull
+spring.datasource.username=taskboard
+spring.datasource.password=taskboard
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+spring.jpa.hibernate.ddl-auto=none
+spring.datasource.log-abandoned=true
+
+#flyway
+# add the following line with the appropriate database
+flyway.locations=db/migration/mysql
+flyway.baseline-on-migrate=true
+flyway.baselineVersionAsString=1
+
+# Followup required properties
+jira.customfield.t-shirt-size.mainTShirtSizeFieldId=customfield_10117
+
+# Done, Deferred, Cancelled,To QA,QAing
+jira.followup.featureStatusThatDontGenerateBallpark=10001,10102,10101,10122,10111
+
+# Cancelled (10101)
+jira.followup.subtaskStatusThatDontPreventBallparkGeneration=
+
+# Open,Deferred
+jira.followup.statusExcludedFromFollowup=1,10102
+
+# Open
+jira.followup.ballparkDefaultStatus=1
+
+# WIP
+jira.wip.ignore-issuetypes-ids=10105,10200,10400
+
+# added 26/07/2017
+
+# GOOGLE API
+google-api.client-secrets-file=./data/google-api/googleapps-credentials.json
+google-api.credential-store-dir=./data/google-api/credentials
+
+# SIZING IMPORT
+sizing-import.data-starting-row-number=6
+sizing-import.value-to-ignore=<NA>
+
+sizing-import.sheet-map.issue-phase=A
+sizing-import.sheet-map.issue-demand=B
+sizing-import.sheet-map.issue-feature=C
+sizing-import.sheet-map.type=D
+sizing-import.sheet-map.issue-key=E
+sizing-import.sheet-map.include=I
+
+sizing-import.sheet-map.extra-fields[0].field-id=customfield_10126
+sizing-import.sheet-map.extra-fields[0].column-header=Assumptions
+sizing-import.sheet-map.extra-fields[0].column-letter=F
+sizing-import.sheet-map.extra-fields[1].field-id=customfield_10120
+sizing-import.sheet-map.extra-fields[1].column-header=Acceptance Criteria
+sizing-import.sheet-map.extra-fields[1].column-letter=G
+
+sizing-import.sheet-map.default-columns[0].field-id=customfield_10105
+sizing-import.sheet-map.default-columns[0].column=O
+sizing-import.sheet-map.default-columns[1].field-id=customfield_10111
+sizing-import.sheet-map.default-columns[1].column=P
+sizing-import.sheet-map.default-columns[2].field-id=customfield_10115
+sizing-import.sheet-map.default-columns[2].column=Q
+sizing-import.sheet-map.default-columns[3].field-id=customfield_10117
+sizing-import.sheet-map.default-columns[3].column=R
+sizing-import.sheet-map.default-columns[4].field-id=customfield_10106
+sizing-import.sheet-map.default-columns[4].column=N
+sizing-import.sheet-map.default-columns[5].field-id=customfield_10110
+sizing-import.sheet-map.default-columns[5].column=K
+sizing-import.sheet-map.default-columns[6].field-id=customfield_10113
+sizing-import.sheet-map.default-columns[6].column=M
+sizing-import.sheet-map.default-columns[7].field-id=customfield_10119
+sizing-import.sheet-map.default-columns[7].column=L
+
+sizing-import.indirect-costs.indirect-costs-column=A
+sizing-import.indirect-costs.issue-key-column=B
+sizing-import.indirect-costs.effort-column=R
+sizing-import.indirect-costs.total-indirect-costs-column=A
+sizing-import.indirect-costs.parent-type-id=10400
+sizing-import.indirect-costs.subtask-type-id=10200
+
+# Execute data history generator every day at midnight
+jira.followup.executionDataHistoryGenerator.cron=0 0 0 * * *
+jira.followup.executionDataHistoryGenerator.timezone=America/Sao_Paulo
+
+# Issue status priority order
+jira.statusPriorityOrder.demands=Cancelled,Done,UATing,To UAT,Doing,To Do,Open
+jira.statusPriorityOrder.tasks=Cancelled,Done,QAing,To QA,To Deploy,Internal QAing,To Internal QA,Developing,To Dev,Planning,To Plan,Open
+jira.statusPriorityOrder.subtasks=Cancelled,Done,Merging,To Merge,Reviewing,To Review,Doing,To Do,Open
+
+# Issue status Counting on Wip
+jira.statusCountingOnWip.demands=Doing,To UAT,UATing
+jira.statusCountingOnWip.tasks=Planning,To Dev,Developing,To Internal QA,Internal QAing,To Deploy,To QA,QAing
+jira.statusCountingOnWip.subtasks=Doing,To Review,Reviewing,To Merge,Merging
+
+# Status Counting On Throughput
+jira.finalStatuses.demands=Cancelled,Done
+jira.finalStatuses.tasks=Cancelled,Done
+jira.finalStatuses.subtasks=Cancelled,Done
+
+# AUTOMATIC SUB-TASK CREATION
+# When "Demand" (10103) executes the transition from "Doing" (10104) to "To UAT" (10124),
+# if it does not already exist, a "UAT" (10111) subtask will be created with summary prefix "UAT for "
+# and the "T-Shirt Size" (customfield_10117) filled with default value "S",
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+jira.subtask-creation[0].issue-type-parent-id=10103
+jira.subtask-creation[0].status-id-from=10104
+jira.subtask-creation[0].status-id-to=10124
+jira.subtask-creation[0].issue-type-id=10111
+jira.subtask-creation[0].summary-prefix=UAT for 
+jira.subtask-creation[0].t-shirt-size-parent-id=
+jira.subtask-creation[0].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[0].t-shirt-size-default-value=S
+jira.subtask-creation[0].transition-id=11
+# jira.subtask-creation[0].custom-field-condition.id=
+# jira.subtask-creation[0].custom-field-condition.value=
+
+# When "Task" (10002) executes the transition from "Open" (1) to "To Dev" (10128),
+# if it does not already exist, a "Sub-Task" (10003) subtask will be created with summary prefix "Sub-Task of "
+# and the "T-Shirt Size" (customfield_10117) filled with default value "S",
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+jira.subtask-creation[1].issue-type-parent-id=10002
+jira.subtask-creation[1].status-id-from=1
+jira.subtask-creation[1].status-id-to=10128
+jira.subtask-creation[1].issue-type-id=10003
+jira.subtask-creation[1].summary-prefix=Sub-Task of 
+jira.subtask-creation[1].t-shirt-size-parent-id=
+jira.subtask-creation[1].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[1].t-shirt-size-default-value=S
+jira.subtask-creation[1].transition-id=11
+#jira.subtask-creation[1].custom-field-condition.id=
+#jira.subtask-creation[1].custom-field-condition.value=
+
+# When "Task" (10002) executes the transition from "Planning" (10127) to "To Dev" (10128),
+# if it does not already exist, a "Sub-Task" (10003) subtask will be created with summary prefix "Sub-Task of "
+# and the "T-Shirt Size" (customfield_10117) filled with default value "S",
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+jira.subtask-creation[1].issue-type-parent-id=10002
+jira.subtask-creation[1].status-id-from=10127
+jira.subtask-creation[1].status-id-to=10128
+jira.subtask-creation[1].issue-type-id=10003
+jira.subtask-creation[1].summary-prefix=Sub-Task of 
+jira.subtask-creation[1].t-shirt-size-parent-id=
+jira.subtask-creation[1].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[1].t-shirt-size-default-value=S
+jira.subtask-creation[1].transition-id=11
+#jira.subtask-creation[1].custom-field-condition.id=
+#jira.subtask-creation[1].custom-field-condition.value=
+
+# When "Task" (10002) executes the transition from "Developing" (10129) to "To Internal QA" (10130),
+# if it does not already exist, a "Feature Review" (10106) subtask will be created with summary prefix "Review of "
+# and the "T-Shirt Size" (customfield_10117) filled with "Feature Review TSize" (customfield_10111) of parent,
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+# or will skip creation if the "Feature Review TSize" of parent has no value.
+jira.subtask-creation[2].issue-type-parent-id=10002
+jira.subtask-creation[2].status-id-from=10129
+jira.subtask-creation[2].status-id-to=10130
+jira.subtask-creation[2].issue-type-id=10106
+jira.subtask-creation[2].summary-prefix=Review of 
+jira.subtask-creation[2].t-shirt-size-parent-id=customfield_10111
+jira.subtask-creation[2].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[2].t-shirt-size-default-value=S
+jira.subtask-creation[2].transition-id=11
+jira.subtask-creation[2].skip-creation-when-t-shirt-parent-is-absent=true
+#jira.subtask-creation[2].custom-field-condition.id=
+#jira.subtask-creation[2].custom-field-condition.value=
+
+# When "Bug" (10004) executes the transition from "Developing" (10129) to "To Internal QA" (10130),
+# if it does not already exist, a "Alpha Test" (10101) subtask will be created with summary prefix "Alpha for "
+# and the "T-Shirt Size" (customfield_10117) filled with "Alpha Test TSize" (customfield_10105) of parent or with default value "S",
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+jira.subtask-creation[3].issue-type-parent-id=10004
+jira.subtask-creation[3].status-id-from=10129
+jira.subtask-creation[3].status-id-to=10130
+jira.subtask-creation[3].issue-type-id=10101
+jira.subtask-creation[3].summary-prefix=Alpha for 
+jira.subtask-creation[3].t-shirt-size-parent-id=customfield_10105
+jira.subtask-creation[3].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[3].t-shirt-size-default-value=S
+jira.subtask-creation[3].transition-id=11
+#jira.subtask-creation[3].custom-field-condition.id=
+#jira.subtask-creation[3].custom-field-condition.value=
+
+# When "Bug" (10004) executes the transition from "Developing" (10129) to "To Internal QA" (10130),
+# if it does not already exist, a "Feature Review" (10106) subtask will be created with summary prefix "Review of "
+# and the "T-Shirt Size" (customfield_10117) filled with "Feature Review TSize" (customfield_10111) of parent,
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+# or will skip creation if the "Feature Review TSize" of parent has no value.
+jira.subtask-creation[4].issue-type-parent-id=10004
+jira.subtask-creation[4].status-id-from=10129
+jira.subtask-creation[4].status-id-to=10130
+jira.subtask-creation[4].issue-type-id=10106
+jira.subtask-creation[4].summary-prefix=Review of 
+jira.subtask-creation[4].t-shirt-size-parent-id=customfield_10111
+jira.subtask-creation[4].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[4].t-shirt-size-default-value=S
+jira.subtask-creation[4].transition-id=11
+jira.subtask-creation[4].skip-creation-when-t-shirt-parent-is-absent=true
+#jira.subtask-creation[4].custom-field-condition.id=
+#jira.subtask-creation[4].custom-field-condition.value=
+
+# When "Bug" (10004) executes the transition from "Developing" (10129) to "To Internal QA" (10130),
+# if it does not already exist, a "Functional Test" (10115) subtask will be created with summary prefix "Functional Test of "
+# and the "T-Shirt Size" (customfield_10117) filled with "Functional Test TSize" (customfield_10201) of parent,
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+# or will skip creation if the "Feature Review TSize" of parent has no value.
+jira.subtask-creation[5].issue-type-parent-id=10004
+jira.subtask-creation[5].status-id-from=10129
+jira.subtask-creation[5].status-id-to=10130
+jira.subtask-creation[5].issue-type-id=10115
+jira.subtask-creation[5].summary-prefix=Functional Test of 
+jira.subtask-creation[5].t-shirt-size-parent-id=customfield_10201
+jira.subtask-creation[5].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[5].t-shirt-size-default-value=S
+jira.subtask-creation[5].transition-id=11
+jira.subtask-creation[5].skip-creation-when-t-shirt-parent-is-absent=true
+#jira.subtask-creation[5].custom-field-condition.id=customfield_10127
+#jira.subtask-creation[5].custom-field-condition.value=Yes
+
+# When "Bug" (10004) executes the transition from "To Deploy" (10200) to "To QA" (10122),
+# if it does not already exist, a "QA" (10108) subtask will be created with summary prefix "QA for "
+# and the "T-Shirt Size" (customfield_10117) filled with "QA Support TSize" (customfield_10115) of parent or with default value "S",
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+jira.subtask-creation[6].issue-type-parent-id=10004
+jira.subtask-creation[6].status-id-from=10200
+jira.subtask-creation[6].status-id-to=10122
+jira.subtask-creation[6].issue-type-id=10108
+jira.subtask-creation[6].summary-prefix=QA for 
+jira.subtask-creation[6].t-shirt-size-parent-id=customfield_10115
+jira.subtask-creation[6].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[6].t-shirt-size-default-value=S
+jira.subtask-creation[6].transition-id=11
+# jira.subtask-creation[6].custom-field-condition.id=
+# jira.subtask-creation[6].custom-field-condition.value=
+
+# When "Bug" (10004) executes the transition from "Open" (1) to "To Plan" (10126),
+# if it does not already exist, a "Tech Planning" (10110) subtask will be created with summary prefix "Tech Planning for "
+# and the "T-Shirt Size" (customfield_10117) filled with "Tech Planning TSize" (customfield_10118) of parent,
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created
+# or will skip creation if the "Tech Planning TSize" of parent has no value.
+jira.subtask-creation[7].issue-type-parent-id=10004
+jira.subtask-creation[7].status-id-from=1
+jira.subtask-creation[7].status-id-to=10126
+jira.subtask-creation[7].issue-type-id=10110
+jira.subtask-creation[7].summary-prefix=Tech Planning for 
+jira.subtask-creation[7].t-shirt-size-parent-id=customfield_10118
+jira.subtask-creation[7].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[7].t-shirt-size-default-value=S
+jira.subtask-creation[7].skip-creation-when-t-shirt-parent-is-absent=true
+jira.subtask-creation[7].transition-id=11
+
+# When "Feature" (10104) executes the transition from "Developing" (10129) to "To Internal QA" (10130),
+# if it does not already exist, a "Alpha Test" (10101) subtask will be created with summary prefix "Alpha for "
+# and the "T-Shirt Size" (customfield_10117) filled with "Alpha Test TSize" (customfield_10105) of parent or with default value "S",
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+jira.subtask-creation[8].issue-type-parent-id=10104
+jira.subtask-creation[8].status-id-from=10129
+jira.subtask-creation[8].status-id-to=10130
+jira.subtask-creation[8].issue-type-id=10101
+jira.subtask-creation[8].summary-prefix=Alpha for 
+jira.subtask-creation[8].t-shirt-size-parent-id=customfield_10105
+jira.subtask-creation[8].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[8].t-shirt-size-default-value=S
+jira.subtask-creation[8].transition-id=11
+#jira.subtask-creation[8].custom-field-condition.id=
+#jira.subtask-creation[8].custom-field-condition.value=
+
+# When "Feature" (10104) executes the transition from "Developing" (10129) to "To Internal QA" (10130),
+# if it does not already exist, a "Feature Review" (10106) subtask will be created with summary prefix "Review of "
+# and the "T-Shirt Size" (customfield_10117) filled with "Feature Review TSize" (customfield_10111) of parent,
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+# or will skip creation if the "Feature Review TSize" of parent has no value.
+jira.subtask-creation[9].issue-type-parent-id=10104
+jira.subtask-creation[9].status-id-from=10129
+jira.subtask-creation[9].status-id-to=10130
+jira.subtask-creation[9].issue-type-id=10106
+jira.subtask-creation[9].summary-prefix=Review of 
+jira.subtask-creation[9].t-shirt-size-parent-id=customfield_10111
+jira.subtask-creation[9].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[9].t-shirt-size-default-value=S
+jira.subtask-creation[9].transition-id=11
+jira.subtask-creation[9].skip-creation-when-t-shirt-parent-is-absent=true
+#jira.subtask-creation[10].custom-field-condition.id=
+#jira.subtask-creation[10].custom-field-condition.value=
+
+# When "Feature" (10104) executes the transition from "Developing" (10129) to "To Internal QA" (10130),
+# if it does not already exist, a "Functional Test" (10115) subtask will be created with summary prefix "Functional Test of "
+# and the "T-Shirt Size" (customfield_10117) filled with "Functional Test TSize" (customfield_10201) of parent,
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+# or will skip creation if the "Feature Review TSize" of parent has no value.
+jira.subtask-creation[10].issue-type-parent-id=10104
+jira.subtask-creation[10].status-id-from=10129
+jira.subtask-creation[10].status-id-to=10130
+jira.subtask-creation[10].issue-type-id=10115
+jira.subtask-creation[10].summary-prefix=Functional Test of 
+jira.subtask-creation[10].t-shirt-size-parent-id=customfield_10201
+jira.subtask-creation[10].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[10].t-shirt-size-default-value=S
+jira.subtask-creation[10].transition-id=11
+jira.subtask-creation[10].skip-creation-when-t-shirt-parent-is-absent=true
+#jira.subtask-creation[10].custom-field-condition.id=customfield_10127
+#jira.subtask-creation[10].custom-field-condition.value=Yes
+
+# When "Feature" (10104) executes the transition from "To Deploy" (10200) to "To QA" (10122),
+# if it does not already exist, a "QA" (10108) subtask will be created with summary prefix "QA for "
+# and the "T-Shirt Size" (customfield_10117) filled with "QA Support TSize" (customfield_10115) of parent or with default value "S",
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created.
+jira.subtask-creation[11].issue-type-parent-id=10104
+jira.subtask-creation[11].status-id-from=10200
+jira.subtask-creation[11].status-id-to=10122
+jira.subtask-creation[11].issue-type-id=10108
+jira.subtask-creation[11].summary-prefix=QA for 
+jira.subtask-creation[11].t-shirt-size-parent-id=customfield_10115
+jira.subtask-creation[11].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[11].t-shirt-size-default-value=S
+jira.subtask-creation[11].transition-id=11
+# jira.subtask-creation[12].custom-field-condition.id=
+# jira.subtask-creation[12].custom-field-condition.value=
+
+# When "Feature" (10104) executes the transition from "Open" (1) to "To Plan" (10126),
+# if it does not already exist, a "Feature Planning" (10105) subtask will be created with summary prefix "Feature Planning for "
+# and the "T-Shirt Size" (customfield_10117) filled with "Feature Planning TSize" (customfield_10110) of parent,
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created
+# or will skip creation if the "Feature Planning TSize" of parent has no value.
+jira.subtask-creation[12].issue-type-parent-id=10104
+jira.subtask-creation[12].status-id-from=1
+jira.subtask-creation[12].status-id-to=10126
+jira.subtask-creation[12].issue-type-id=10105
+jira.subtask-creation[12].summary-prefix=Feature Planning for 
+jira.subtask-creation[12].t-shirt-size-parent-id=customfield_10110
+jira.subtask-creation[12].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[12].t-shirt-size-default-value=S
+jira.subtask-creation[12].skip-creation-when-t-shirt-parent-is-absent=true
+jira.subtask-creation[12].transition-id=11
+
+# When "Feature" (10104) executes the transition from "Open" (1) to "To Plan" (10126),
+# if it does not already exist, a "Tech Planning" (10110) subtask will be created with summary prefix "Tech Planning for "
+# and the "T-Shirt Size" (customfield_10117) filled with "Tech Planning TSize" (customfield_10118) of parent,
+# and will try to execute the transition (11) from "Open" to "To Do" of subtask found or created
+# or will skip creation if the "Tech Planning TSize" of parent has no value.
+jira.subtask-creation[13].issue-type-parent-id=10104
+jira.subtask-creation[13].status-id-from=1
+jira.subtask-creation[13].status-id-to=10126
+jira.subtask-creation[13].issue-type-id=10110
+jira.subtask-creation[13].summary-prefix=Tech Planning for 
+jira.subtask-creation[13].t-shirt-size-parent-id=customfield_10118
+jira.subtask-creation[13].t-shirt-size-subtask-id=customfield_10117
+jira.subtask-creation[13].t-shirt-size-default-value=S
+jira.subtask-creation[13].skip-creation-when-t-shirt-parent-is-absent=true
+jira.subtask-creation[13].transition-id=11
+

--- a/src/main/resources/objective-properties/application-dev.properties
+++ b/src/main/resources/objective-properties/application-dev.properties
@@ -1,0 +1,193 @@
+spring.jpa.hibernate.ddl-auto=none
+
+logging.level.objective.taskboard=DEBUG
+
+#DATASOURCE
+spring.datasource.url=jdbc:oracle:thin:@jiraup2.cf9iayfqbnvt.us-west-2.rds.amazonaws.com:1521:jira
+#spring.datasource.url=jdbc:oracle:thin:@jira-teste.cf9iayfqbnvt.us-west-2.rds.amazonaws.com:1521/jira
+spring.datasource.username=taskboard
+spring.datasource.password=taskboard
+
+#JIRA
+jira.url=http://10.44.1.37:8080
+#jira.url=http://10.44.1.99:8080
+jira.lousa.username=lousa
+jira.lousa.password=objective
+
+
+jira.customfield.t-shirt-size.ids=customfield_10450,customfield_11244,customfield_11245,customfield_11246,customfield_11247,customfield_11340,customfield_11341
+jira.customfield.t-shirt-size.extra-small=PP
+jira.customfield.t-shirt-size.small=P
+jira.customfield.t-shirt-size.medium=M
+jira.customfield.t-shirt-size.large=G
+jira.customfield.t-shirt-size.extra-large=GG
+jira.customfield.class-of-service.id=customfield_10740
+jira.customfield.class-of-service.colors.0=#EEEEEE
+jira.customfield.class-of-service.colors.11181=#EEEEEE
+jira.customfield.class-of-service.colors.11182=#FF8B94
+jira.customfield.class-of-service.colors.11183=#FEE5BC
+jira.customfield.class-of-service.colors.11184=#ADD9FE
+jira.customfield.blocked.id=customfield_10940
+jira.customfield.blocked.yes-option-id=11680
+jira.customfield.last-block-reason.id=customfield_11243
+jira.customfield.co-assignees.id=customfield_10370
+jira.customfield.additional-estimated-hours.id=
+jira.customfield.release.id=customfield_11454
+jira.customfield.assigned-teams.id=customfield_11640
+#jira.customfield.acceptance-criteria.id=
+
+jira.issuelink.dependencies=Requirement
+jira.issuelink.demand-id=10150
+
+jira.issuetype.demand.id=7
+jira.issuetype.default-feature.id=5
+
+jira.issuetype.features[0].id=11
+jira.issuetype.features[0].name=Atividade
+
+jira.issuetype.features[1].id=5
+jira.issuetype.features[1].name=OS
+
+jira.issuetype.features[2].id=4
+jira.issuetype.features[2].name=Bug
+
+jira.issuetype.features[3].id=23
+jira.issuetype.features[3].name=OSSuporte
+
+jira.issuetype.features[4].id=34
+jira.issuetype.features[4].name=OSConsultoria
+
+#Analise Desenvolvimento, Tarefa de fabrica, sub-task, bug de alfa, experiencia do usuario, reintegracao de branch, preparacao producao, teste (alfa)
+jira.issuetype.subtasks[0].id=32
+jira.issuetype.subtasks[1].id=9
+jira.issuetype.subtasks[2].id=12
+jira.issuetype.subtasks[3].id=10002
+jira.issuetype.subtasks[4].id=10500
+jira.issuetype.subtasks[5].id=10006
+jira.issuetype.subtasks[6].id=10005
+jira.issuetype.subtasks[7].id=21
+
+jira.statuses-canceled-ids=10004
+jira.statuses-completed-ids=10053,6
+# Postergado
+jira.statuses-deferred-ids=10855
+
+jira.transitions-done-names=Done,Fechar
+jira.transitions-cancel-names=Cancelar
+jira.transitions-with-required-comment-names=Cancelar,Impedir,Desimpedir,Cancel,Block,Unblock
+
+jira.resolutions.done.name=Done
+jira.resolutions.canceled.name=Canceled
+
+flyway.locations=db/migration/oracle
+flyway.baseline-on-migrate=true
+flyway.baselineVersionAsString=201802210850
+
+#LINK GRAPH
+linkgraph.url=http://10.44.1.18:8080/sr/br.com.objective.jira.plugin.linkgraph.linkgraph:linkgraph-search-request-view/temp/SearchRequest.html?jqlQuery=key=
+
+# main tshirt custom field
+jira.customfield.t-shirt-size.mainTShirtSizeFieldId=customfield_10450
+
+# Resolvido, Fechado, Cancelado, Orçado, Done, Recebido
+jira.followup.featureStatusThatDontGenerateBallpark=5,6,10004,10024,10053,10754
+
+# Cancelado
+jira.followup.subtaskStatusThatDontPreventBallparkGeneration=10004
+
+# Aberto
+jira.followup.statusExcludedFromFollowup=1
+jira.followup.ballparkDefaultStatus=1
+
+# GOOGLE API (credentials file is in the team folder)
+google-api.client-secrets-file=./data/google-api/googleapps-credentials.json
+google-api.credential-store-dir=./data/google-api/credentials
+
+# SIZING IMPORT
+sizing-import.data-starting-row-number=6
+sizing-import.value-to-ignore=<NA>
+
+sizing-import.sheet-map.issue-phase=A
+sizing-import.sheet-map.issue-demand=B
+sizing-import.sheet-map.issue-feature=C
+sizing-import.sheet-map.type=D
+sizing-import.sheet-map.issue-key=E
+sizing-import.sheet-map.issue-acceptance-criteria=F
+sizing-import.sheet-map.include=H
+
+sizing-import.sheet-map.default-columns[0].field-id=customfield_11244
+sizing-import.sheet-map.default-columns[0].column=K
+sizing-import.sheet-map.default-columns[1].field-id=customfield_11341
+sizing-import.sheet-map.default-columns[1].column=N
+sizing-import.sheet-map.default-columns[2].field-id=customfield_11245
+sizing-import.sheet-map.default-columns[2].column=Q
+sizing-import.sheet-map.default-columns[3].field-id=customfield_11246
+sizing-import.sheet-map.default-columns[3].column=T
+sizing-import.sheet-map.default-columns[4].field-id=customfield_11247
+sizing-import.sheet-map.default-columns[4].column=W
+sizing-import.sheet-map.default-columns[5].field-id=customfield_11340
+sizing-import.sheet-map.default-columns[5].column=Z
+
+# Execute data history generator every day at midnight
+jira.followup.executionDataHistoryGenerator.cron=0 0 0 * * *
+jira.followup.executionDataHistoryGenerator.timezone=America/Sao_Paulo
+
+# Issue status priority order
+jira.statusPriorityOrder.demands=Cancelado,Fechado,Beta-Teste,Integrado,Desenvolvimento,Planejamento Aprovado,Aprovação Planejamento,Planejamento,Aprovação Especificação,Especificação Funcional,OG,Aberto
+jira.statusPriorityOrder.tasks=Cancelado,Fechado,Beta-Teste,Integrado,Desenvolvimento,Aguardando Desenvolvimento,Planejamento,Priorizado,Aberto
+jira.statusPriorityOrder.subtasks=Cancelado,Done,Review,To Review,In Progress,To Do,Aberto
+
+#Issue statuses to be count on Throughput
+jira.finalStatuses.demands=Cancelado,Fechado,Beta-Teste,Integrado
+jira.finalStatuses.tasks=Cancelado,Fechado,Beta-Teste,Integrado
+jira.finalStatuses.subtasks=Cancelado,Fechado
+
+#Issue statuses to be count on WIP
+jira.statusCountingOnWip.demands=OG,Especificação Funcional,Aprovação Especificação,Planejamento,Aprovação Planejamento,Planejamento Aprovado,Desenvolvimento
+jira.statusCountingOnWip.tasks=Planejamento,Aguardando Desenvolvimento,Desenvolvimento
+jira.statusCountingOnWip.subtasks=In Progress,To Review,Review
+
+# AUTOMATIC SUB-TASK CREATION
+# When "OS" (5) executes the transition from "Planejamento" (10152) to "Desenvolvimento" (10017),
+# if it does not already exist, a "Tarefa de Fï¿½brica" (9) subtask will be created with summary of parent
+# and the "Tamanho" (customfield_10450) filled with "Desenvolvimento Tamanho" (customfield_11245) of parent or with default value "P",
+# and will not try to execute the transition of subtask found or created.
+jira.subtask-creation[0].issue-type-parent-id=5
+jira.subtask-creation[0].status-id-from=10152
+jira.subtask-creation[0].status-id-to=10017
+jira.subtask-creation[0].issue-type-id=9
+jira.subtask-creation[0].summary-prefix=
+jira.subtask-creation[0].t-shirt-size-parent-id=customfield_11245
+jira.subtask-creation[0].t-shirt-size-subtask-id=customfield_10450
+jira.subtask-creation[0].t-shirt-size-default-value=P
+jira.subtask-creation[0].transition-id=
+
+# AUTOMATIC SUB-TASK CREATION
+# When "Bug" (4) executes the transition from "Planejamento" (10152) to "Desenvolvimento" (10017),
+# if it does not already exist, a "Tarefa de Fï¿½brica" (9) subtask will be created with summary of parent
+# and the "Tamanho" (customfield_10450) filled with "Desenvolvimento Tamanho" (customfield_11245) of parent or with default value "P",
+# and will not try to execute the transition of subtask found or created.
+jira.subtask-creation[1].issue-type-parent-id=4
+jira.subtask-creation[1].status-id-from=10152
+jira.subtask-creation[1].status-id-to=10017
+jira.subtask-creation[1].issue-type-id=9
+jira.subtask-creation[1].summary-prefix=
+jira.subtask-creation[1].t-shirt-size-parent-id=customfield_11245
+jira.subtask-creation[1].t-shirt-size-subtask-id=customfield_10450
+jira.subtask-creation[1].t-shirt-size-default-value=P
+jira.subtask-creation[1].transition-id=
+
+# AUTOMATIC SUB-TASK CREATION
+# When "OS" (5) executes the transition from "Planejamento" (10152) to "Aguardando Desenvolvimento" (11051),
+# if it does not already exist, a "Tarefa de Fï¿½brica" (9) subtask will be created with summary of parent
+# and the "Tamanho" (customfield_10450) filled with "Desenvolvimento Tamanho" (customfield_11245) of parent or with default value "P",
+# and will not try to execute the transition of subtask found or created.
+jira.subtask-creation[2].issue-type-parent-id=5
+jira.subtask-creation[2].status-id-from=10152
+jira.subtask-creation[2].status-id-to=11051
+jira.subtask-creation[2].issue-type-id=9
+jira.subtask-creation[2].summary-prefix=
+jira.subtask-creation[2].t-shirt-size-parent-id=customfield_11245
+jira.subtask-creation[2].t-shirt-size-subtask-id=customfield_10450
+jira.subtask-creation[2].t-shirt-size-default-value=P
+jira.subtask-creation[2].transition-id=

--- a/src/main/resources/static/elements/taskboard/kpis/kpis-dashboard.html
+++ b/src/main/resources/static/elements/taskboard/kpis/kpis-dashboard.html
@@ -380,6 +380,19 @@
                 ready: function () {
                     this.populateProjects();
                     this.set('user', taskboard.getLoggedUser());
+                    // register callback to resize all highcharts charts 
+                    // when the browser window is resized
+                    window.addEventListener('resize', function() {
+                        ChartUtils.scheduleResize(200);
+                    });
+
+                    // adds the reversed option in the tooltip
+                    Highcharts.wrap(Highcharts.Tooltip.prototype, "refresh", function(proceed, items, event) {
+                        if(this.options.reversed && this.options.shared) {
+                            items.reverse();
+                        }
+                        proceed.call(this, items, event);
+                    });
                 },
 
                 populateProjects: function() {
@@ -445,6 +458,7 @@
                     var categoryClicked = event.target.dataset.category;
                     this._activeCategory(categoryClicked);
 
+                    ChartUtils.resizeAllHighchartsCharts();
                     dc.renderAll();
                 },
 

--- a/src/main/resources/static/elements/taskboard/kpis/widget-throughput.html
+++ b/src/main/resources/static/elements/taskboard/kpis/widget-throughput.html
@@ -22,17 +22,25 @@
   <template>
 
     <style>
+        .widget__body {
+            display: flex;
+        }
+        #throughput {
+            display: flex;
+            height: 100%;
+            width: 100%;
+        }
     </style>
 
     <widget-wrap title="Throughput" is-ready="{{isReady}}" tags="{{tags}}"
         error-message="{{errorMessage}}" options="{{options}}"
-        chart="{{chart}}">
+        highcharts-chart="{{chart}}">
       <div id="throughput" class="tb-chart"></div>
     </widget-wrap> 
     <modal-wrap class="filters-modal" title="Filters">
       <modal-wrap-content>
         <h3 class="tb-label">Issue Types</h3>
-        <div class="config-slot-0 dc-chart--no-float"></div>
+        <div id="issueTypes" class="config-slot-0 dc-chart--no-float"></div>
       </modal-wrap-content>
       <modal-wrap-footer> 
         <tb-button button=[[_btFilterClose]]></tb-button>
@@ -107,12 +115,15 @@
                     }
                 },
         
-                _onProjectSelected: function (newSelectedProjectKey, oldSelectedProjectKey) {
+                _onProjectSelected: function (newSelectedProjectKey, previousSelectedProjectKey) {
+                    if (newSelectedProjectKey === previousSelectedProjectKey) {
+                        return;
+                    }
                     this.reloadChart();
                 },
 
                 _getSavedLevel: function () {
-                    return window.localStorage.getItem(this.localStorageLevelItemName) || 'Subtask';
+                    return localStorage.getItem(this.localStorageLevelItemName) || 'Subtask';
                 },
 
                 computeLocalStorageLevelItemName: function (selectedProjectKey) {
@@ -128,7 +139,7 @@
                             this.$$('.settings-modal').close();
                             return;
                         }
-                        window.localStorage.setItem(this.localStorageLevelItemName, this.settingIssueLevel);
+                        localStorage.setItem(this.localStorageLevelItemName, this.settingIssueLevel);
                         this.$$('.settings-modal').close();
                         this.reloadChart();
                     }).build();
@@ -144,21 +155,10 @@
                         this.xhr = null;
                     }
                     if (this.chart) {
-                        dcDateRangeChartsService.deregisterChartInRange(this.chart);
-                        dc.deregisterChart(this.chart);
+                        dcDateRangeChartsService.deregisterHighchartsChart(this.chart.title.textStr);
+                        this.chart.destroy();
                         this.chart = null;
                     }
-                },
-                handleError: function (error, data) {
-                    if (error) {
-                        this.errorMessage = error.responseText;
-                        return true;
-                    }
-                    if (!data.rows.length) {
-                        this.errorMessage = 'Throughput has no data';
-                        return true;
-                    }
-                    return false;
                 },
         
                 reloadChart: function () {
@@ -167,17 +167,21 @@
                     const timezone = taskboard.getTimeZoneIdFromBrowser();
                     this.tags = [savedLevel];
                     const url = `/api/projects/${this.selectedProjectKey}/followup/throughput?level=${savedLevel}&timezone=${timezone}`;
-                    this.xhr = d3.json(url, (error, data) => {
-                        if (this.handleError(error, data)) {
+                    this.xhr = $.getJSON(url);
+                    this.xhr.done((data) => {
+                        data = data.rows;
+                        if (!data.length) {
+                            this.errorMessage = 'Throughput has no data';
                             return;
                         }
-                        data = data.rows;
         
-                        const plotData = this.prepareData(data);
-                        this.issueListFilter = this.createIssueListFilter(plotData.ndx);
-                        this.chart = this.createChart(plotData);
-                        dcDateRangeChartsService.registerChartInRangeAndRender(this.chart);
+                        this.plotData = this.prepareData(data);
+                        this.createIssueTypeFilter();
+                        this.createChart();
                         this.isReady = true;
+                    });
+                    this.xhr.fail((error) => {
+                        this.errorMessage = error.responseText;
                     });
                 },
 
@@ -189,17 +193,22 @@
                         // clean-up
                         delete item.count;
                     });
-                    const [startDate, endDate] = d3.extent(data, (item) => item.date);
-                    const ndx = dc.crossfilter(data);
+                    const issueTypes = _.chain(data).map((item) => item.issueType).unique().value();
+
+                    const startDate = data[0].date;
+                    const endDate = data[data.length - 1].date;
+                    
+                    const ndx = crossfilter(data);
                     // Date as dimension
-                    const dimension = ndx.dimension((item) => item.date);
-                    // extract issue types into a array without repetition
-                    const issueTypes = [...new Set(data.map((item) => item.issueType))];
-                    const dateGroup = dimension.group();
+                    const dateDimension = ndx.dimension((item) => item.date);
+                    const typeDimension = ndx.dimension((item) => item.issueType);
+
+                    const dateGroup = dateDimension.group();
                     dcUtils.groupChartDataByGroupKey(dateGroup, 'issueType', 'throughput');
                     return Object.freeze({
                         ndx: ndx,
-                        dimension: dimension,
+                        dateDimension: dateDimension,
+                        typeDimension: typeDimension,
                         startDate: startDate,
                         endDate: endDate,
                         issueTypes: issueTypes,
@@ -207,29 +216,47 @@
                     });
                 },
 
-                createIssueListFilter: function (ndx) {
+                createIssueTypeFilter: function () {
                     this.set('options.0.hidden', false);
-                    const div = this.$$('.config-slot-0');
-                    const typeDimension = ndx.dimension((item) => item.issueType);
-                    const list = dcUtils.createPaperListFilter(div, typeDimension, '-none-', 'All Issues');
-                    list.render();
-                    list.on('filtered', () => {
-                        const className = list.isAllSelected() ? '' : 'widget__button_highlighted';
-                        this.set('options.0.cssClasses', className);
+                    const div = this.$.issueTypes;
+                    ChartUtils.createIssueTypeFilter(div, this.plotData.issueTypes, () => {
+                        const checkboxes = this.querySelectorAll('input[name=issueType]');
+                        const selectedTypes = Array.from(checkboxes).filter((cb) => cb.checked).map((cb) => cb.value);
+                        this.plotData.typeDimension.filterFunction((issueType) => selectedTypes.includes(issueType));
+                        const toggleAllCheckbox = this.querySelector('input[name=allTypesToggle]');
+                        this.set('options.0.cssClasses', toggleAllCheckbox.checked ? '' : 'widget__button_highlighted');
+                        this.createChart();
                     });
-                    return list;
                 },
 
-                createChart: function (plotData) {
-                    const chart = dc.barChart('#throughput');
-                    dcUtils.configureDefaultStackedChart(chart);
-                    dcUtils.insertPlotDataIntoChart(chart, plotData, 'issueTypes');
-                    // present legends in reverse order
-                    dcUtils.reverseLegendOrder(chart);
-                    dcUtils.setupChartDateTicks(chart, plotData.startDate, plotData.endDate, 12);
-                    return chart;
+                createChart: function () {
+                    const dataGroupedByDate = this.plotData.dateGroup.all();
+                    const series = new Map();
+                    const oneWeekInMillis = 7 * 24 * 3600 * 1000;
+                    this.plotData.issueTypes.forEach((type) => {
+                        series.set(type, {
+                            name: type,
+                            data: [],
+                            pointStart: this.plotData.startDate.getTime(),
+                            pointInterval: oneWeekInMillis
+                        });
+                    });
+                    dataGroupedByDate.forEach((item) => {
+                        this.plotData.issueTypes.forEach((type) => {
+                            const throughputSumByWeek = item.value[type];
+                            series.get(type).data.push(throughputSumByWeek);
+                        });
+                    });
+                    const seriesPlot = [...series.values()];
+                    const builder = new WeeklyChartBuilder('throughput')
+                        .withTitle('Throughput')
+                        .withChartType('column')
+                        .withSeriesData(seriesPlot);
+                    this.chart = builder.build();
+                    dcDateRangeChartsService.registerHighchartsChart(this.chart.title.textStr, this.chart);
+                    dcDateRangeChartsService.applySelection(this.chart.title.textStr);
                 }
             });
         })();
-  </script> 
+    </script> 
 </dom-module>

--- a/src/main/resources/static/elements/taskboard/kpis/widget-wip.html
+++ b/src/main/resources/static/elements/taskboard/kpis/widget-wip.html
@@ -22,22 +22,30 @@
   <template>
 
     <style>
+        .widget__body {
+            display: flex;
+        }
+        #wip {
+            display: flex;
+            height: 100%;
+            width: 100%;
+        }
     </style>
 
     <widget-wrap title="WIP" is-ready="{{isReady}}" tags="{{tags}}"
         error-message="{{errorMessage}}" options="{{options}}"
-        chart="{{chart}}">
+        highcharts-chart="{{chart}}">
       <div id="wip" class="tb-chart"></div>
     </widget-wrap> 
     <modal-wrap class="filters-modal" title="Filters">
       <modal-wrap-content>
         <h3 class="tb-label">Issue Types</h3>
-        <div class="config-slot-0 dc-chart--no-float"></div>
-        </modal-wrap-content>
-        <modal-wrap-footer> 
+        <div id="issueTypes" class="config-slot-0 dc-chart--no-float"></div>
+      </modal-wrap-content>
+      <modal-wrap-footer> 
         <tb-button button=[[_btFilterClose]]></tb-button>
-        </modal-wrap-footer>
-      </modal-wrap>
+      </modal-wrap-footer>
+    </modal-wrap>
     <modal-wrap class="settings-modal" title="Settings">
       <modal-wrap-content>
         <h3 class="tb-label">Level</h3>
@@ -92,12 +100,15 @@
                     settingIssueLevel: {
                         type: String,
                         notify: true,
-                        value: 'Subtask',
-                        observer: '_onSettingIssueLevelChanged'
+                        value: 'Subtask'
                     },
                     localStorageLevelItemName: {
                         type: String,
                         computed: 'computeLocalStorageLevelItemName(selectedProjectKey)'
+                    },
+                    plotData: {
+                        type: Object,
+                        value: null
                     },
                     _btFilterClose: {
                         type: Object,
@@ -117,7 +128,7 @@
                 },
 
                 _getSavedLevel: function () {
-                    return window.localStorage.getItem(this.localStorageLevelItemName) || 'Subtask';
+                    return localStorage.getItem(this.localStorageLevelItemName) || 'Subtask';
                 },
 
                 computeLocalStorageLevelItemName: function (selectedProjectKey) {
@@ -133,7 +144,7 @@
                             this.$$('.settings-modal').close();
                             return;
                         }
-                        window.localStorage.setItem(this.localStorageLevelItemName, this.settingIssueLevel);
+                        localStorage.setItem(this.localStorageLevelItemName, this.settingIssueLevel);
                         this.$$('.settings-modal').close();
                         this.reloadChart();
                     }).build();
@@ -149,22 +160,10 @@
                         this.xhr = null;
                     }
                     if (this.chart) {
-                        dcDateRangeChartsService.deregisterChartInRange(this.chart);
-                        dc.deregisterChart(this.chart);
+                        dcDateRangeChartsService.deregisterHighchartsChart(this.chart.title.textStr);
+                        this.chart.destroy();
                         this.chart = null;
                     }
-                },
-
-                handleError: function (error, data) {
-                    if (error) {
-                        this.errorMessage = error.responseText;
-                        return true;
-                    }
-                    if (!data.rows.length) {
-                        this.errorMessage = 'WIP has no data';
-                        return true;
-                    }
-                    return false;
                 },
 
                 reloadChart: function () {
@@ -173,16 +172,20 @@
                     const timezone = taskboard.getTimeZoneIdFromBrowser();
                     this.tags = [savedLevel];
                     const url = `/api/projects/${this.selectedProjectKey}/followup/wip?level=${savedLevel}&timezone=${timezone}`;
-                    this.xhr = d3.json(url, (error, data) => {
-                        if (this.handleError(error, data)) {
+                    this.xhr = $.getJSON(url);
+                    this.xhr.done((data) => {
+                        data = data.rows;
+                        if (!data.length) {
+                            this.errorMessage = 'WIP has no data';
                             return;
                         }
-                        data = data.rows;
-                        const plotData = this.prepareData(data);
-                        this.issueListFilter = this.createIssueListFilter(plotData.ndx);
-                        this.chart = this.createChart(plotData);
-                        dcDateRangeChartsService.registerChartInRangeAndRender(this.chart);
+                        this.plotData = this.prepareData(data);
+                        this.createIssueTypeFilter();
+                        this.createChart();
                         this.isReady = true;
+                    });
+                    this.xhr.fail((error) => {
+                        this.errorMessage = error.responseText;
                     });
                 },
 
@@ -190,53 +193,78 @@
                     // parsing data from controller
                     data.forEach((item) => {
                         item.date = new Date(Number(item.date));
-                        item.wip = Number(item.count);
+                        item.date.setHours(0, 0, 0, 0);
+                        item.wip = Number(item.average);
                         // clean-up
-                        delete item.count;
+                        delete item.average;
                     });
+                    const issueStatuses = _.chain(data).map((item) => item.issueStatus).unique().value();
+                    const issueTypes = _.chain(data).map((item) => item.issueType).unique().value();
 
-                    const [startDate, endDate] = d3.extent(data, (item) => item.date);
+                    const startDate = data[0].date;
+                    const endDate = data[data.length - 1].date;
 
-                    const ndx = dc.crossfilter(data);
+                    const ndx = crossfilter(data);
                     // Date as dimension
-                    const dimension = ndx.dimension((item) => item.date);
-                    // extract statuses into a array without repetition
-                    const issueStatuses = [...new Set(data.map((item) => item.status))];
-                    const dateGroup = dimension.group();
-                    dcUtils.groupChartDataByGroupKey(dateGroup, 'status', 'wip');
+                    const dateDimension = ndx.dimension((item) => item.date);
+                    const typeDimension = ndx.dimension((item) => item.issueType);
+
+                    const dateGroup = dateDimension.group();
+                    dcUtils.groupChartDataByGroupKey(dateGroup, 'issueStatus', 'wip');
                     return Object.freeze({
                         ndx: ndx,
-                        dimension: dimension,
+                        dateDimension: dateDimension,
+                        typeDimension: typeDimension,
                         startDate: startDate,
                         endDate: endDate,
                         issueStatuses: issueStatuses,
+                        issueTypes: issueTypes,
                         dateGroup: dateGroup
                     });
                 },
 
-                createIssueListFilter: function (ndx) {
+                createIssueTypeFilter: function () {
                     this.set('options.0.hidden', false);
-                    const div = this.$$('.config-slot-0');
-                    const typeDimension = ndx.dimension((item) => item.type);
-                    const list = dcUtils.createPaperListFilter(div, typeDimension, '-none-', 'All Issues');
-                    list.render();
-                    list.on('filtered', () => {
-                        const className = list.isAllSelected() ? '' : 'widget__button_highlighted';
-                        this.set('options.0.cssClasses', className);
+                    const div = this.$.issueTypes;
+                    ChartUtils.createIssueTypeFilter(div, this.plotData.issueTypes, () => {
+                        const checkboxes = this.querySelectorAll('input[name=issueType]');
+                        const selectedTypes = Array.from(checkboxes).filter((cb) => cb.checked).map((cb) => cb.value);
+                        this.plotData.typeDimension.filterFunction((issueType) => selectedTypes.includes(issueType));
+                        const toggleAllCheckbox = this.querySelector('input[name=allTypesToggle]');
+                        this.set('options.0.cssClasses', toggleAllCheckbox.checked ? '' : 'widget__button_highlighted');
+                        this.createChart();
                     });
-                    return list;
                 },
 
-                createChart: function (plotData) {
-                    const chart = dc.barChart('#wip');
-                    dcUtils.configureDefaultStackedChart(chart);
-                    dcUtils.insertPlotDataIntoChart(chart, plotData, 'issueStatuses');
-                    // present legends in reverse order
-                    dcUtils.reverseLegendOrder(chart);
-                    dcUtils.setupChartDateTicks(chart, plotData.startDate, plotData.endDate, 12);
-                    return chart;
+                createChart: function () {
+                    const dataGroupedByDate = this.plotData.dateGroup.all();
+                    const series = new Map();
+                    const oneWeekInMillis = 7 * 24 * 3600 * 1000;
+                    this.plotData.issueStatuses.forEach((status) => {
+                        series.set(status, {
+                            name: status,
+                            data: [],
+                            pointStart: this.plotData.startDate.getTime(),
+                            pointInterval: oneWeekInMillis
+                        });
+                    });
+                    dataGroupedByDate.forEach((item) => {
+                        this.plotData.issueStatuses.forEach((status) => {
+                            const wipAvg = Number(item.value[status].toFixed(5));
+                            series.get(status).data.push(wipAvg);
+                        });
+                    });
+                    const seriesPlot = [...series.values()];
+                    const builder = new WeeklyChartBuilder('wip')
+                        .withTitle('WIP')
+                        .withChartType('column')
+                        .withTooltipNumberOfDecimals(2)
+                        .withSeriesData(seriesPlot);
+                    this.chart = builder.build();
+                    dcDateRangeChartsService.registerHighchartsChart(this.chart.title.textStr, this.chart);
+                    dcDateRangeChartsService.applySelection(this.chart.title.textStr);
                 }
             });
         })();
-  </script> 
+    </script> 
 </dom-module>

--- a/src/main/resources/static/elements/taskboard/kpis/widget-wrap.html
+++ b/src/main/resources/static/elements/taskboard/kpis/widget-wrap.html
@@ -240,6 +240,11 @@
                         type: Object,
                         notify: true
                     },
+                    highchartsChart: {
+                        type: Object,
+                        notify: false,
+                        value: null
+                    },
                     _isChartFiltered: {
                         type: Boolean,
                         value: false
@@ -357,7 +362,19 @@
 
                 _onTapDownload: function() {
                     var fileName = this.title.replace(/ /g, '_') + "_" + getDateHour();
-                    dcUtils.downloadElementAsJpegImage(this.$$('.widget__body'), fileName);
+                    if (!this.highchartsChart) {
+                        dcUtils.downloadElementAsJpegImage(this.$$('.widget__body'), fileName);
+                        return;
+                    }
+                    const exportOptions = {
+                        filename: fileName
+                    }
+                    const chartOptions = {
+                        chart: {
+                            backgroundColor: '#565656'
+                        }
+                    }
+                    this.highchartsChart.exportChartLocal(exportOptions, chartOptions);
                 }
             });
         })();

--- a/src/main/resources/static/scripts/chart-utils.js
+++ b/src/main/resources/static/scripts/chart-utils.js
@@ -1,0 +1,206 @@
+
+class ChartUtils {
+    static getDefaultHighchartsOptions () {
+        const options = {
+            colors: ['#53B873', '#E72915', '#FFCF0F', '#EE3771', '#9DCB6A', '#FA6A01', '#AA5DBC', '#5DAFFF', '#FF8C80', '#FCE196', '#B5E5FB', '#CD95D7', '#FFB25D', '#F290B1'],
+            chart: {
+                backgroundColor: 'transparent',
+                zoomType: 'xy'
+            },
+            exporting: {
+                enabled: true
+            },
+            legend: {
+                align: 'left',
+                itemHiddenStyle: {
+                    color: '#666'
+                },
+                itemHoverStyle: {
+                    color: '#8E8E8E'
+                },
+                itemStyle: {
+                    color: '#8E8E8E'
+                },
+                layout: 'vertical',
+                reversed: true,
+                verticalAlign: 'top'
+            },
+            plotOptions: {
+                series: {
+                    stacking: 'normal'
+                }
+            },
+            title: {
+                style: {
+                    color: '#8E8E8E'
+                }
+            },
+            tooltip: {
+                footerFormat: '<span style="font-style: italic; font-weight: bold; font-size: 1.1em;">Total: {point.total:.2f}</span>',
+                shared: true,
+                reversed: true
+            },
+            xAxis: {
+                labels: {
+                    style: {
+                        color: '#8E8E8E'
+                    }
+                },
+                lineColor: '#8E8E8E',
+                startOfWeek: 0,
+                tickColor: '#8E8E8E',
+                type: 'datetime'
+            },
+            yAxis: {
+                gridLineColor: '#CCC',
+                labels: {
+                    style: {
+                        color: '#8E8E8E'
+                    }
+                },
+                reversedStacks: false,
+                title: {
+                    style: {
+                        color: '#8E8E8E'
+                    },
+                    text: undefined
+                }
+            },
+            navigation: {
+                buttonOptions: {
+                    enabled: false
+                }
+            }
+        };
+        return options;
+    }
+
+    static createIssueTypeFilter (div, issueTypes, filterCallback) {
+
+        function createInputCheckbox (name, value, checked) {
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.name = name;
+            checkbox.value = value;
+            checkbox.checked = checked;
+            return checkbox;
+        }
+
+        function createFilterItem (labelText, checkboxName, checkboxValue, checkboxChecked) {
+            const label = document.createElement('label');
+            const checkbox = createInputCheckbox(checkboxName, checkboxValue, checkboxChecked);
+            checkbox.addEventListener('click', function () {
+                const checkboxes = document.querySelectorAll(`#${div.id} input[name=issueType]`);
+                const allSelected = checkboxes.length === Array.from(checkboxes).filter((cb) => cb.checked).length;
+                const toggleAllCheckbox = document.querySelector(`#${div.id} input[name=allTypesToggle]`);
+                toggleAllCheckbox.checked = allSelected;
+                filterCallback();
+            });
+            label.appendChild(checkbox);
+            label.appendChild(document.createTextNode(labelText));
+            return label;
+        }
+
+        while (div.firstChild) {
+            div.removeChild(div.firstChild);
+        }
+
+        const toggleAllCheckbox = createInputCheckbox('allTypesToggle', 'allTypesToggle', true);
+        toggleAllCheckbox.addEventListener('click', function () {
+            const checkboxes = document.querySelectorAll(`#${div.id} input[name=issueType]`);
+            checkboxes.forEach((cb) => cb.checked = this.checked);
+            filterCallback();
+        });
+        const label = document.createElement('label');
+        label.appendChild(toggleAllCheckbox);
+        label.appendChild(document.createTextNode('All Types'));
+        div.appendChild(label);
+        div.appendChild(document.createElement('hr'));
+        issueTypes.slice().reverse().forEach((issueType) => {
+            const item = createFilterItem(issueType, 'issueType', issueType, true);
+            div.appendChild(item);
+            div.appendChild(document.createElement('br'));
+        });
+    }
+
+    static resizeAllHighchartsCharts () {
+        /* 
+         * This function performs a resize on all Highchart charts.
+         *
+         * It is necessary because when the chart is first loaded, the 
+         * container (div) has no size set, then the chart's size falls 
+         * back to the lib's default size which gives an erroneous size.
+         */
+        Highcharts.charts.forEach((chart) => {
+            if (chart) {
+                const chartDiv = chart.container;
+                // section is the first ancestral that has the correct height
+                const section = chartDiv.closest('section');
+                const header = section.children[0];
+                const borderSizeWidgetBody = 16;
+                const height = section.offsetHeight - header.offsetHeight - borderSizeWidgetBody * 2;
+                const width = section.offsetWidth - borderSizeWidgetBody * 2;
+                chart.setSize(width, height);
+            }
+        });
+    }
+
+    static scheduleResize (afterMillis) {
+        if (!ChartUtils.timeout) {
+            ChartUtils.timeout = setTimeout(() => {
+                ChartUtils.resizeAllHighchartsCharts();
+                delete ChartUtils.timeout;
+            }, afterMillis);
+        }
+    }
+}
+
+class WeeklyChartBuilder {
+    constructor (divID) {
+        this.options = ChartUtils.getDefaultHighchartsOptions();
+        this.options.chart.renderTo = divID;
+        const oneWeekInMillis = 7 * 24 * 3600 * 1000;
+        this.options.xAxis.tickInterval = oneWeekInMillis;
+        this.options.xAxis.labels = {
+            formatter: function () {
+                return Highcharts.dateFormat('%e %b %y', this.value);
+            }
+        };
+        this.options.chart.events = {
+            selection: function (event) {
+                if (event.resetSelection) {
+                    this.resetZoomButton = this.resetZoomButton.destroy(); // hide reset button
+                    event.preventDefault(); // prevent zoom out
+                    this.yAxis[0].setExtremes(null, null); // reset Y
+                    dcDateRangeChartsService.applySelection(this.title.textStr); // reset X to timeline selection
+                }
+            }
+        };
+        this.options.tooltip.xDateFormat = 'Week from %A, %b %e, %Y';
+    }
+
+    withTitle (title) {
+        this.options.title.text = title;
+        return this;
+    }
+
+    withChartType(chartType) {
+        this.options.chart.type = chartType;
+        return this;
+    }
+
+    withTooltipNumberOfDecimals (numberOfDecimals) {
+        this.options.tooltip.valueDecimals = numberOfDecimals;
+        return this;
+    }
+
+    withSeriesData (seriesData) {
+        this.options.series = seriesData;
+        return this;
+    }
+
+    build () {
+        const chart = Highcharts.chart(this.options);
+        return chart;
+    }
+}

--- a/src/main/resources/static/scripts/dc-date-range-charts-service.js
+++ b/src/main/resources/static/scripts/dc-date-range-charts-service.js
@@ -8,6 +8,8 @@ function DcDateRangeChartsService() {
 
     self._registeredCharts = new Map();
 
+    self._highchartCharts = new Map();
+
     self._isBrushing = false;
 
     self.resizeOptions = {
@@ -91,17 +93,36 @@ function DcDateRangeChartsService() {
         if (!self._rangeChart.filter() || !self._rangeChart.brushOn())
             self._resetSelection();
         else
-            self._applySelection();
+            self.applySelectionToAll();
     };
 
-    self._applySelection = function() {
+    self.applySelectionToAll = function() {
+        const timelineRange = self._brushRange.value();
         self._registeredCharts.forEach(function(registeredChart) {
-            if (!dcUtils.rangesEqual(self._brushRange.value(), registeredChart.filter())) {
+            if (!dcUtils.rangesEqual(timelineRange, registeredChart.filter())) {
                 dc.events.trigger(function () {
                     self._applyFocusOnChart(registeredChart);
                 });
             }
         });
+        self._highchartCharts.forEach((chart) => {
+            const min = timelineRange[0].getTime();
+            const max = timelineRange[1].getTime();
+            chart.xAxis[0].setExtremes(min, max);
+        })
+    };
+
+    self.applySelection = function(chartName) {
+        const chart = self._highchartCharts.get(chartName);
+
+        if (!chart) {
+            return;
+        } 
+
+        const timelineRange = self._brushRange.value();
+        const min = timelineRange[0].getTime();
+        const max = timelineRange[1].getTime();
+        chart.xAxis[0].setExtremes(min, max);
     };
 
     self._resetSelection = function() {
@@ -124,6 +145,14 @@ function DcDateRangeChartsService() {
             });
         });
     };
+
+    self.registerHighchartsChart = function (chartName, chart) {
+        self._highchartCharts.set(chartName, chart);
+    }
+
+    self.deregisterHighchartsChart = function (chartName) {
+        self._highchartCharts.delete(chartName);
+    }
 
 }
 

--- a/src/main/resources/static/scripts/dc-utils.js
+++ b/src/main/resources/static/scripts/dc-utils.js
@@ -279,29 +279,25 @@ function DcUtils() {
 
     this.groupChartDataByGroupKey = function (crossfilterGroup, groupPropertyNameKey, valuePropertyNameKey) {
         const reduceAdd = (p, v) => {
-            if (!p) {
-                p = {};
+            const groupingKey = v[groupPropertyNameKey];
+            if (p[groupingKey] === undefined) {
+                p[groupingKey] = 0;
             }
-            if (!p[v[groupPropertyNameKey]]) {
-                p[v[groupPropertyNameKey]] = 0;
-            }
-            p[v[groupPropertyNameKey]] += v[valuePropertyNameKey];
+            p[groupingKey] += v[valuePropertyNameKey];
             return p;
         };
         const reduceSub = (p, v) => {
-            if (!p) {
-                p = {};
+            const groupingKey = v[groupPropertyNameKey];
+            if (p[groupingKey] === undefined) {
+                p[groupingKey] = 0;
             }
-            if (!p[v[groupPropertyNameKey]]) {
-                p[v[groupPropertyNameKey]] = 0;
-            }
-            p[v[groupPropertyNameKey]] -= v[valuePropertyNameKey];
+            p[groupingKey] -= v[valuePropertyNameKey];
             return p;
         };
         const reduceInit = () => {
             return {};
         };
-        crossfilterGroup.reduce(reduceAdd, reduceSub, reduceInit)
+        crossfilterGroup.reduce(reduceAdd, reduceSub, reduceInit);
     }
 
 }

--- a/src/main/resources/templates/followup-dashboard.html
+++ b/src/main/resources/templates/followup-dashboard.html
@@ -82,12 +82,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="/static/bower_components/d3/d3.js"></script>
     <script src="/static/bower_components/dcjs/dc.js"></script>
     <script src="/static/bower_components/dom-to-image/dist/dom-to-image.min.js"></script>
+    <script src="/static/bower_components/highcharts/highcharts.js"></script>
+    <script src="/static/bower_components/highcharts/modules/exporting.js"></script>
+    <script src="/static/bower_components/highcharts/modules/offline-exporting.js"></script>
 
     <script src="/static/scripts/tb-pie-chart.js"></script>
     <script src="/static/scripts/dc-paperlist.js"></script>
 
     <script src="/static/scripts/utils.js"></script>
     <script src="/static/scripts/dc-utils.js"></script>
+    <script src="/static/scripts/chart-utils.js"></script>
     <script src="/static/scripts/dc-date-range-charts-service.js"></script>
     <script src="/static/scripts/3rd/jstz.min.js"></script>
     <script src="/static/scripts/taskboard.js"></script>

--- a/src/test/java/objective/taskboard/followup/WeekRangeNormalizerTest.java
+++ b/src/test/java/objective/taskboard/followup/WeekRangeNormalizerTest.java
@@ -1,0 +1,229 @@
+package objective.taskboard.followup;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import org.apache.commons.lang3.Range;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import objective.taskboard.utils.DateTimeUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WeekRangeNormalizerTest {
+
+    private static final ZoneId ZONE_ID = ZoneId.systemDefault();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private FollowUpTimeline timeline;
+
+    @Test
+    public void normalizeWeekRange_whenTimelineStartsOnSundayAndEndsOnSaturday_thenNoRoundingNeeded() {
+        Range<ZonedDateTime> dataSetDateRange = createDateRange("2018-09-04", "2018-09-21", ZONE_ID);
+        Range<ZonedDateTime> timelineDateRange = createDateRange("2018-09-09", "2018-09-15", ZONE_ID);
+    
+        assertDayOfWeekBoundaries(dataSetDateRange, DayOfWeek.TUESDAY, DayOfWeek.FRIDAY);
+        assertDayOfWeekBoundaries(timelineDateRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+    
+        mockTimeline(timelineDateRange);
+    
+        Range<ZonedDateTime> actualWeekRange = WeekRangeNormalizer.normalizeWeekRange(timeline, dataSetDateRange, ZONE_ID);
+    
+        Range<ZonedDateTime> expectedWeekRange = createDateRange("2018-09-09", "2018-09-15", ZONE_ID);
+    
+        assertTrue(actualWeekRange.equals(expectedWeekRange));
+        assertDayOfWeekBoundaries(actualWeekRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+    }
+
+    @Test
+    public void normalizeWeekRange_whenTimelineStartsOnTuesdayAndEndsOnFriday_thenRoundingDownStartDateToSundayAndRoundingUpEndDateToSaturday() {
+        Range<ZonedDateTime> dataSetDateRange = createDateRange("2018-09-04", "2018-09-21", ZONE_ID);
+        Range<ZonedDateTime> timelineDateRange = createDateRange("2018-09-04", "2018-09-21", ZONE_ID);
+
+        assertDayOfWeekBoundaries(dataSetDateRange, DayOfWeek.TUESDAY, DayOfWeek.FRIDAY);
+        assertDayOfWeekBoundaries(timelineDateRange, DayOfWeek.TUESDAY, DayOfWeek.FRIDAY);
+
+        mockTimeline(timelineDateRange);
+
+        Range<ZonedDateTime> actualWeekRange = WeekRangeNormalizer.normalizeWeekRange(timeline, dataSetDateRange, ZONE_ID);
+
+        Range<ZonedDateTime> expectedWeekRange = createDateRange("2018-09-02", "2018-09-22", ZONE_ID);
+
+        assertTrue(actualWeekRange.equals(expectedWeekRange));
+        assertDayOfWeekBoundaries(actualWeekRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+    }
+
+    @Test
+    public void normalizeWeekRange_whenEmptyTimeline_thenRoundingDownDataSetStartDateToSundayAndRoundingUpDataSetEndDateToSaturday() {
+        Range<ZonedDateTime> dataSetDateRange = createDateRange("2018-09-04", "2018-09-21", ZONE_ID);
+        
+        assertDayOfWeekBoundaries(dataSetDateRange, DayOfWeek.TUESDAY, DayOfWeek.FRIDAY);
+
+        final Optional<LocalDate> timelineStartDate = Optional.empty();
+        final Optional<LocalDate> timelineEndDate = Optional.empty();
+
+        mockTimeline(timelineStartDate, timelineEndDate);
+
+        Range<ZonedDateTime> actualWeekRange = WeekRangeNormalizer.normalizeWeekRange(timeline, dataSetDateRange, ZONE_ID);
+
+        Range<ZonedDateTime> expectedWeekRange = createDateRange("2018-09-02", "2018-09-22", ZONE_ID);
+
+        assertTrue(actualWeekRange.equals(expectedWeekRange));
+        assertDayOfWeekBoundaries(actualWeekRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);        
+    }
+
+    @Test
+    public void normalizeWeekRange_whenTimelineEmptyStartDateAndEndsOnSaturday_thenRoundingDownDataSetStartDateToSunday() {
+        Range<ZonedDateTime> dataSetDateRange = createDateRange("2018-09-04", "2018-09-21", ZONE_ID);
+        
+        assertDayOfWeekBoundaries(dataSetDateRange, DayOfWeek.TUESDAY, DayOfWeek.FRIDAY);
+
+        final Optional<LocalDate> timelineStartDate = Optional.empty();
+        final Optional<LocalDate> timelineEndDate = Optional.of(LocalDate.parse("2018-09-15"));
+        assertThat(timelineEndDate.get().getDayOfWeek(), is(DayOfWeek.SATURDAY));
+        
+        mockTimeline(timelineStartDate, timelineEndDate);
+
+        Range<ZonedDateTime> actualWeekRange = WeekRangeNormalizer.normalizeWeekRange(timeline, dataSetDateRange, ZONE_ID);
+
+        Range<ZonedDateTime> expectedWeekRange = createDateRange("2018-09-02", "2018-09-15", ZONE_ID);
+
+        assertTrue(actualWeekRange.equals(expectedWeekRange));
+        assertDayOfWeekBoundaries(actualWeekRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+    }
+
+    @Test
+    public void normalizeWeekRange_whenTimelineStartsOnSundayAndEmptyEndDate_thenRoundingUpDataSetEndDateToSaturday() {
+        Range<ZonedDateTime> dataSetDateRange = createDateRange("2018-09-04", "2018-09-21", ZONE_ID);
+        
+        assertDayOfWeekBoundaries(dataSetDateRange, DayOfWeek.TUESDAY, DayOfWeek.FRIDAY);
+
+        final Optional<LocalDate> timelineStartDate = Optional.of(LocalDate.parse("2018-09-09"));
+        final Optional<LocalDate> timelineEndDate = Optional.empty();
+        assertThat(timelineStartDate.get().getDayOfWeek(), is(DayOfWeek.SUNDAY));
+        
+        mockTimeline(timelineStartDate, timelineEndDate);
+
+        Range<ZonedDateTime> actualWeekRange = WeekRangeNormalizer.normalizeWeekRange(timeline, dataSetDateRange, ZONE_ID);
+
+        Range<ZonedDateTime> expectedWeekRange = createDateRange("2018-09-09", "2018-09-22", ZONE_ID);
+
+        assertTrue(actualWeekRange.equals(expectedWeekRange));
+        assertDayOfWeekBoundaries(actualWeekRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+    }
+
+    @Test
+    public void normalizeWeekRange_whenEmptyTimelineAndDataSetStartsOnSundayAndEndsOnSaturday_thenNoRoundingNeeded() {
+        Range<ZonedDateTime> dataSetDateRange = createDateRange("2018-09-09", "2018-09-22", ZONE_ID);
+        
+        assertDayOfWeekBoundaries(dataSetDateRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+
+        final Optional<LocalDate> timelineStartDate = Optional.empty();
+        final Optional<LocalDate> timelineEndDate = Optional.empty();
+        
+        mockTimeline(timelineStartDate, timelineEndDate);
+
+        Range<ZonedDateTime> actualWeekRange = WeekRangeNormalizer.normalizeWeekRange(timeline, dataSetDateRange, ZONE_ID);
+
+        Range<ZonedDateTime> expectedWeekRange = createDateRange("2018-09-09", "2018-09-22", ZONE_ID);
+
+        assertTrue(actualWeekRange.equals(expectedWeekRange));
+        assertDayOfWeekBoundaries(actualWeekRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+    }
+
+    @Test
+    public void normalizeWeekRange_whenTimelineAndDataSetRangesFromSundayToSaturday_thenNoRoundingNeededAndRespectsTimelineRange() {
+        Range<ZonedDateTime> dataSetDateRange = createDateRange("2018-09-09", "2018-09-22", ZONE_ID);
+        Range<ZonedDateTime> timelineDateRange = createDateRange("2018-09-02", "2018-09-29", ZONE_ID);
+
+        assertDayOfWeekBoundaries(dataSetDateRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+        assertDayOfWeekBoundaries(timelineDateRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+
+        mockTimeline(timelineDateRange);
+
+        Range<ZonedDateTime> actualWeekRange = WeekRangeNormalizer.normalizeWeekRange(timeline, dataSetDateRange, ZONE_ID);
+
+        Range<ZonedDateTime> expectedWeekRange = createDateRange("2018-09-02", "2018-09-29", ZONE_ID);
+
+        assertTrue(actualWeekRange.equals(expectedWeekRange));
+        assertDayOfWeekBoundaries(actualWeekRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+        assertThat(actualWeekRange.getMinimum().getDayOfMonth(), is(2));
+        assertThat(actualWeekRange.getMaximum().getDayOfMonth(), is(29));
+    }
+
+    @Test
+    public void normalizeWeekRange_whenTimelineStartDateAfterTimelineEndDate_thenError() {
+        Range<ZonedDateTime> dataSetDateRange = createDateRange("2018-09-09", "2018-09-22", ZONE_ID);
+        
+        assertDayOfWeekBoundaries(dataSetDateRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+
+        Optional<LocalDate> timelineStartDate = Optional.of(LocalDate.parse("2018-09-16"));
+        assertThat(timelineStartDate.get().getDayOfWeek(), is(DayOfWeek.SUNDAY));
+        Optional<LocalDate> timelineEndDate = Optional.of(LocalDate.parse("2018-09-10"));
+        assertThat(timelineEndDate.get().getDayOfWeek(), is(DayOfWeek.MONDAY));
+
+        mockTimeline(timelineStartDate, timelineEndDate);
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Start date is after end date!");
+
+        WeekRangeNormalizer.normalizeWeekRange(timeline, dataSetDateRange, ZONE_ID);
+    }
+
+    @Test
+    public void normalizeWeekRange_whenTimelineStartDateAfterDataSetEndDateAndTimelineEndDateEmpty__thenError() {
+        Range<ZonedDateTime> dataSetDateRange = createDateRange("2018-09-09", "2018-09-22", ZONE_ID);
+        
+        assertDayOfWeekBoundaries(dataSetDateRange, DayOfWeek.SUNDAY, DayOfWeek.SATURDAY);
+
+        Optional<LocalDate> timelineStartDate = Optional.of(LocalDate.parse("2018-09-24"));
+        assertThat(timelineStartDate.get().getDayOfWeek(), is(DayOfWeek.MONDAY));
+        Optional<LocalDate> timelineEndDate = Optional.empty();
+
+        mockTimeline(timelineStartDate, timelineEndDate);
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Start date is after end date!");
+
+        WeekRangeNormalizer.normalizeWeekRange(timeline, dataSetDateRange, ZONE_ID);
+    }
+
+    private void mockTimeline(Range<ZonedDateTime> timelineDateRange) {
+        Optional<LocalDate> timelineStartDate = Optional.of(timelineDateRange.getMinimum().toLocalDate());
+        Optional<LocalDate> timelineEndDate = Optional.of(timelineDateRange.getMaximum().toLocalDate());
+    
+        mockTimeline(timelineStartDate, timelineEndDate);
+    }
+    
+    private void mockTimeline(Optional<LocalDate> startDate, Optional<LocalDate> endDate) {
+        Mockito.when(timeline.getStart()).thenReturn(startDate);
+        Mockito.when(timeline.getEnd()).thenReturn(endDate);
+    }
+
+    private Range<ZonedDateTime> createDateRange(String startDate, String endDate, ZoneId zone) {
+        ZonedDateTime dataSetStartDate = LocalDate.parse(startDate).atStartOfDay(zone);
+        ZonedDateTime dataSetEndDate = LocalDate.parse(endDate).atStartOfDay(zone);
+        return DateTimeUtils.range(dataSetStartDate, dataSetEndDate);
+    }
+
+    private void assertDayOfWeekBoundaries(Range<ZonedDateTime> dateRange, DayOfWeek startDayOfWeek, DayOfWeek endDayOfWeek) {
+        assertThat(dateRange.getMinimum().getDayOfWeek(), is(startDayOfWeek));
+        assertThat(dateRange.getMaximum().getDayOfWeek(), is(endDayOfWeek));
+    }
+
+}

--- a/src/test/java/objective/taskboard/followup/WipKPIDataProviderTest.java
+++ b/src/test/java/objective/taskboard/followup/WipKPIDataProviderTest.java
@@ -7,13 +7,18 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,9 +38,10 @@ import objective.taskboard.followup.kpi.WipKPIService;
 @RunWith(MockitoJUnitRunner.class)
 public class WipKPIDataProviderTest {
 
-    public static final String TYPE_DEMAND = "Demand";
-    public static final String TYPE_FEATURES = "Features";
-    public static final String TYPE_SUBTASKS = "Subtasks";
+    private static final String LEVEL_ALL = "All";
+    private static final String LEVEL_DEMANDS = "Demand";
+    private static final String LEVEL_FEATURES = "Feature";
+    private static final String LEVEL_SUBTASKS = "Subtask";
     private static final ZoneId ZONE_ID = ZoneId.systemDefault();
 
     @Rule
@@ -49,201 +55,779 @@ public class WipKPIDataProviderTest {
 
     @Mock
     private WipKPIService wipKpiService;
-
+    
     @Spy
+    private WeekRangeNormalizer weekRangeNormalizer = new WeekRangeNormalizer();
+
     @InjectMocks
     private WipKPIDataProvider subject = new WipKPIDataProvider();
 
     @Test
-    public void getWipChartDataSet_happyDay() {
+    public void getWipChartDataSet_whenTimelineRangeEqualsDataSetRange_thenNotFiltering() {
         String projectKey = "TASKB";
-        String issueLevel = "Subtask";
+        String issueLevel = LEVEL_ALL;
         
         new TestEnvConfigurator(projectKey)
-                .withTimelineWithinRange()
-                .withDemands().withFeatures().withSubtasks()
-                .configure();
-
-        WipChartDataSet dsSubtasks = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
-
-        assertThat(dsSubtasks.rows.size(), is(4));
-        assertRow(dsSubtasks.rows.get(0), "Dev", "Doing", 0L, "2017-09-25");
-        assertRow(dsSubtasks.rows.get(1), "Dev", "Doing", 1L, "2017-09-26");
-        assertRow(dsSubtasks.rows.get(2), "Dev", "Doing", 2L, "2017-09-27");
-        assertRow(dsSubtasks.rows.get(3), "Dev", "Doing", 1L, "2017-09-28");
-    }
-
-    @Test
-    public void getWipChartDataSet_timelineShortThanDateRangeFromData() {
-        String projectKey = "TASKB";
-        String issueLevel = "Subtask";
-        
-        new TestEnvConfigurator(projectKey)
-                .withShorterTimeline()
-                .withDemands().withFeatures().withSubtasks()
-                .configure();
-
-        WipChartDataSet dsSubtasks = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
-
-        assertThat(dsSubtasks.rows.size(), is(0));
-    }
-
-    @Test
-    public void getWipChartDataSet_timelineLongerThanDataRangeFromData() {
-        String projectKey = "TASKB";
-        String issueLevel = "Subtask";
-        
-        new TestEnvConfigurator(projectKey)
-            .withLongerTimeline()
-            .withDemands().withFeatures().withSubtasks()
+            .withTimelineReferenceDate("2018-09-25")
+            .withTimelineStartDate("2018-09-25")
+            .withTimelineDeliveryDate("2018-10-05")
+            .withTimelineBaselineDate("2018-09-25")
+            .withDemands(
+                    row("Demand").withStatus("Development").at("2018-09-25").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-26").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-27").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-28").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-29").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-30").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-01").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-02").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-03").withWIP(2),
+                    row("Demand").withStatus("Development").at("2018-10-04").withWIP(2),
+                    row("Demand").withStatus("Development").at("2018-10-05").withWIP(2))
+            .withFeatures(
+                    row("Bug").withStatus("Development").at("2018-09-25").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-25").withWIP(2),
+                    row("Bug").withStatus("Development").at("2018-09-26").withWIP(1),
+                    row("Task").withStatus("Development").at("2018-09-26").withWIP(4),
+                    row("Bug").withStatus("Development").at("2018-09-27").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-27").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-09-28").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-28").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-09-29").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-29").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-09-30").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-30").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-01").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-01").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-02").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-02").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-03").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-03").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-04").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-04").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-05").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-05").withWIP(1))
+            .withSubtasks(
+                    row("Alpha Test").withStatus("Doing").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-25").withWIP(6),
+                    row("Backend Development").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-26").withWIP(8),
+                    row("Backend Development").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-27").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-27").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-27").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-27").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-28").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-28").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-28").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-28").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-29").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-29").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-29").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-29").withWIP(1),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-30").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-30").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-01").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-01").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-01").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-01").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-02").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-02").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-02").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-02").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-03").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-03").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-03").withWIP(3),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-04").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-04").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-05").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-05").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-05").withWIP(5),
+                    row("Backend Development").withStatus("Review").at("2018-10-05").withWIP(0))
             .configure();
 
-        WipChartDataSet dsSubtasks = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+        WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
 
-        assertThat(dsSubtasks.rows.size(), is(0));
+        assertThat(ds.rows.size(), is(14));
+        assertRow(ds.rows.get(0), "Demand", "Development", 1.0, "2018-09-23");
+        assertRow(ds.rows.get(1), "Demand", "Development", 1.5, "2018-09-30");
+        assertRow(ds.rows.get(2), "Bug", "Development", 0.2, "2018-09-23");
+        assertRow(ds.rows.get(3), "Task", "Development", 1.8, "2018-09-23");
+        assertRow(ds.rows.get(4), "Bug", "Development", 0.0, "2018-09-30");
+        assertRow(ds.rows.get(5), "Task", "Development", 1.0, "2018-09-30");
+        assertRow(ds.rows.get(6), "Alpha Test", "Doing", 0.0, "2018-09-23");
+        assertRow(ds.rows.get(7), "Alpha Test", "Review", 0.0, "2018-09-23");
+        assertRow(ds.rows.get(8), "Backend Development", "Doing", 5.2, "2018-09-23");
+        assertRow(ds.rows.get(9), "Backend Development", "Review", 1.0, "2018-09-23");
+        assertRow(ds.rows.get(10), "Alpha Test", "Doing", 1.0, "2018-09-30");
+        assertRow(ds.rows.get(11), "Alpha Test", "Review", 0.5, "2018-09-30");
+        assertRow(ds.rows.get(12), "Backend Development", "Doing", 4.0, "2018-09-30");
+        assertRow(ds.rows.get(13), "Backend Development", "Review", 0.0, "2018-09-30");
     }
 
     @Test
-    public void getWipChartDataSet_fetchDataFromAllLevels() {
+    public void getWipChartDataSet_whenTimelineRangeBeforeDataSetDateRange_thenReturnsEmptyDataSet() {
         String projectKey = "TASKB";
-        String issueLevel = "All";
-
-        new TestEnvConfigurator(projectKey)
-            .withTimelineWithinRange()
-            .withDemands().withFeatures().withSubtasks()
-            .configure();
-
-        WipChartDataSet dsAllLevels = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
-
-        assertThat(dsAllLevels.rows.size(), is(12));
-        assertRow(dsAllLevels.rows.get(0), "Demand", "Doing", 0L, "2017-09-25");
-        assertRow(dsAllLevels.rows.get(1), "OS", "Doing", 0L, "2017-09-25");
-        assertRow(dsAllLevels.rows.get(2), "Demand", "Doing", 1L, "2017-09-26");
-        assertRow(dsAllLevels.rows.get(3), "OS", "Doing", 1L, "2017-09-26");
-        assertRow(dsAllLevels.rows.get(4), "Demand", "Doing", 0L, "2017-09-27");
-        assertRow(dsAllLevels.rows.get(5), "OS", "Doing", 1L, "2017-09-27");
-        assertRow(dsAllLevels.rows.get(6), "Feature", "Doing", 0L, "2017-09-25");
-        assertRow(dsAllLevels.rows.get(7), "Feature", "Doing", 1L, "2017-09-26");
-        assertRow(dsAllLevels.rows.get(8), "Dev", "Doing", 0L, "2017-09-25");
-        assertRow(dsAllLevels.rows.get(9), "Dev", "Doing", 1L, "2017-09-26");
-        assertRow(dsAllLevels.rows.get(10), "Dev", "Doing", 2L, "2017-09-27");
-        assertRow(dsAllLevels.rows.get(11), "Dev", "Doing", 1L, "2017-09-28");
-    }
-
-    @Test
-    public void getWipChartDataSet_withoutSubtasksDataSet() {
-        String projectKey = "TASKB";
-        String issueLevel = "All";
+        String issueLevel = LEVEL_SUBTASKS;
         
         new TestEnvConfigurator(projectKey)
-            .withDemands().withFeatures()
+            .withTimelineReferenceDate("2018-09-25")
+            .withTimelineStartDate("2018-09-17")
+            .withTimelineDeliveryDate("2018-09-21")
+            .withTimelineBaselineDate("2018-09-17")
+            .withDemands()
+            .withFeatures()
+            .withSubtasks(
+                    row("Alpha Test").withStatus("Doing").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-25").withWIP(6),
+                    row("Backend Development").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-26").withWIP(8),
+                    row("Backend Development").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-27").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-27").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-27").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-27").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-28").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-28").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-28").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-28").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-29").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-29").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-29").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-29").withWIP(1),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-30").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-30").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-01").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-01").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-01").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-01").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-02").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-02").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-02").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-02").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-03").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-03").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-03").withWIP(3),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-04").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-04").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-05").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-05").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-05").withWIP(5),
+                    row("Backend Development").withStatus("Review").at("2018-10-05").withWIP(0))
             .configure();
 
-        final WipChartDataSet dsAllLevels = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+        WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
 
-        assertThat(dsAllLevels.rows.size(), is(8));
-        assertRow(dsAllLevels.rows.get(0), "Demand", "Doing", 0L, "2017-09-25");
-        assertRow(dsAllLevels.rows.get(1), "OS", "Doing", 0L, "2017-09-25");
-        assertRow(dsAllLevels.rows.get(2), "Demand", "Doing", 1L, "2017-09-26");
-        assertRow(dsAllLevels.rows.get(3), "OS", "Doing", 1L, "2017-09-26");
-        assertRow(dsAllLevels.rows.get(4), "Demand", "Doing", 0L, "2017-09-27");
-        assertRow(dsAllLevels.rows.get(5), "OS", "Doing", 1L, "2017-09-27");
-        assertRow(dsAllLevels.rows.get(6), "Feature", "Doing", 0L, "2017-09-25");
-        assertRow(dsAllLevels.rows.get(7), "Feature", "Doing", 1L, "2017-09-26");
+        assertThat(ds.rows.size(), is(0));
     }
 
     @Test
-    public void getWipChartDataSet_timelineDatesEmptyDatasetEmpty() {
+    public void getWipChartDataSet_whenTimelineRangeAfterDataSetDateRange_thenReturnsEmptyDateSet() {
         String projectKey = "TASKB";
-        String issueLevel = "All";
-
+        String issueLevel = LEVEL_SUBTASKS;
+        
         new TestEnvConfigurator(projectKey)
-                .configure();
+            .withTimelineReferenceDate("2018-09-25")
+            .withTimelineStartDate("2018-10-08")
+            .withTimelineDeliveryDate("2018-10-12")
+            .withTimelineBaselineDate("2018-10-08")
+            .withDemands()
+            .withFeatures()
+            .withSubtasks(
+                    row("Alpha Test").withStatus("Doing").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-25").withWIP(6),
+                    row("Backend Development").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-26").withWIP(8),
+                    row("Backend Development").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-27").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-27").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-27").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-27").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-28").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-28").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-28").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-28").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-29").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-29").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-29").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-29").withWIP(1),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-30").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-30").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-01").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-01").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-01").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-01").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-02").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-02").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-02").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-02").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-03").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-03").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-03").withWIP(3),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-04").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-04").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-05").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-05").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-05").withWIP(5),
+                    row("Backend Development").withStatus("Review").at("2018-10-05").withWIP(0))
+            .configure();
+
+        WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+
+        assertThat(ds.rows.size(), is(0));
+    }
+    
+    @Test
+    public void getWipChartDataSet_whenTimelineRangeStartsBeforeAndEndsWithinDataSetDateRange_thenFiltersEndOnly() {
+        String projectKey = "TASKB";
+        String issueLevel = LEVEL_SUBTASKS;
+        
+        new TestEnvConfigurator(projectKey)
+            .withTimelineReferenceDate("2018-09-25")
+            .withTimelineStartDate("2018-09-20")
+            .withTimelineDeliveryDate("2018-09-29")
+            .withTimelineBaselineDate("2018-09-20")
+            .withDemands()
+            .withFeatures()
+            .withSubtasks(
+                    row("Alpha Test").withStatus("Doing").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-25").withWIP(6),
+                    row("Backend Development").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-26").withWIP(8),
+                    row("Backend Development").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-27").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-27").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-27").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-27").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-28").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-28").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-28").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-28").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-29").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-29").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-29").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-29").withWIP(1),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-30").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-30").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-01").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-01").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-01").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-01").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-02").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-02").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-02").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-02").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-03").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-03").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-03").withWIP(3),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-04").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-04").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-05").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-05").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-05").withWIP(5),
+                    row("Backend Development").withStatus("Review").at("2018-10-05").withWIP(0))
+            .configure();
+
+        WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+
+        assertThat(ds.rows.size(), is(4));
+        assertRow(ds.rows.get(0), "Alpha Test", "Doing", 0.0, "2018-09-23");
+        assertRow(ds.rows.get(1), "Alpha Test", "Review", 0.0, "2018-09-23");
+        assertRow(ds.rows.get(2), "Backend Development", "Doing", 5.2, "2018-09-23");
+        assertRow(ds.rows.get(3), "Backend Development", "Review", 1.0, "2018-09-23");
+    }
+
+    @Test
+    public void getWipChartDataSet_whenTimelineRangeStartsWithinAndEndsAfterDataSetDateRange_thenFiltersBeginOnly() {
+        String projectKey = "TASKB";
+        String issueLevel = LEVEL_SUBTASKS;
+        
+        new TestEnvConfigurator(projectKey)
+        .withTimelineReferenceDate("2018-09-25")
+        .withTimelineStartDate("2018-09-30")
+        .withTimelineDeliveryDate("2018-10-08")
+        .withTimelineBaselineDate("2018-09-20")
+        .withDemands()
+        .withFeatures()
+        .withSubtasks(
+                row("Alpha Test").withStatus("Doing").at("2018-09-25").withWIP(0),
+                row("Alpha Test").withStatus("Review").at("2018-09-25").withWIP(0),
+                row("Backend Development").withStatus("Doing").at("2018-09-25").withWIP(6),
+                row("Backend Development").withStatus("Review").at("2018-09-25").withWIP(0),
+                row("Alpha Test").withStatus("Doing").at("2018-09-26").withWIP(0),
+                row("Alpha Test").withStatus("Review").at("2018-09-26").withWIP(0),
+                row("Backend Development").withStatus("Doing").at("2018-09-26").withWIP(8),
+                row("Backend Development").withStatus("Review").at("2018-09-26").withWIP(0),
+                row("Alpha Test").withStatus("Doing").at("2018-09-27").withWIP(0),
+                row("Alpha Test").withStatus("Review").at("2018-09-27").withWIP(0),
+                row("Backend Development").withStatus("Doing").at("2018-09-27").withWIP(4),
+                row("Backend Development").withStatus("Review").at("2018-09-27").withWIP(2),
+                row("Alpha Test").withStatus("Doing").at("2018-09-28").withWIP(0),
+                row("Alpha Test").withStatus("Review").at("2018-09-28").withWIP(0),
+                row("Backend Development").withStatus("Doing").at("2018-09-28").withWIP(4),
+                row("Backend Development").withStatus("Review").at("2018-09-28").withWIP(2),
+                row("Alpha Test").withStatus("Doing").at("2018-09-29").withWIP(0),
+                row("Alpha Test").withStatus("Review").at("2018-09-29").withWIP(0),
+                row("Backend Development").withStatus("Doing").at("2018-09-29").withWIP(4),
+                row("Backend Development").withStatus("Review").at("2018-09-29").withWIP(1),
+                row("Alpha Test").withStatus("Doing").at("2018-09-30").withWIP(1),
+                row("Alpha Test").withStatus("Review").at("2018-09-30").withWIP(0),
+                row("Backend Development").withStatus("Doing").at("2018-09-30").withWIP(4),
+                row("Backend Development").withStatus("Review").at("2018-09-30").withWIP(0),
+                row("Alpha Test").withStatus("Doing").at("2018-10-01").withWIP(1),
+                row("Alpha Test").withStatus("Review").at("2018-10-01").withWIP(1),
+                row("Backend Development").withStatus("Doing").at("2018-10-01").withWIP(4),
+                row("Backend Development").withStatus("Review").at("2018-09-01").withWIP(0),
+                row("Alpha Test").withStatus("Doing").at("2018-10-02").withWIP(1),
+                row("Alpha Test").withStatus("Review").at("2018-10-02").withWIP(1),
+                row("Backend Development").withStatus("Doing").at("2018-10-02").withWIP(4),
+                row("Backend Development").withStatus("Review").at("2018-10-02").withWIP(0),
+                row("Alpha Test").withStatus("Doing").at("2018-10-03").withWIP(1),
+                row("Alpha Test").withStatus("Review").at("2018-10-03").withWIP(1),
+                row("Backend Development").withStatus("Doing").at("2018-10-03").withWIP(3),
+                row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                row("Alpha Test").withStatus("Doing").at("2018-10-04").withWIP(1),
+                row("Alpha Test").withStatus("Review").at("2018-10-04").withWIP(0),
+                row("Backend Development").withStatus("Doing").at("2018-10-04").withWIP(4),
+                row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                row("Alpha Test").withStatus("Doing").at("2018-10-05").withWIP(1),
+                row("Alpha Test").withStatus("Review").at("2018-10-05").withWIP(0),
+                row("Backend Development").withStatus("Doing").at("2018-10-05").withWIP(5),
+                row("Backend Development").withStatus("Review").at("2018-10-05").withWIP(0))
+        .configure();
+
+        WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+
+        assertThat(ds.rows.size(), is(4));
+        assertRow(ds.rows.get(0), "Alpha Test", "Doing", 1.0, "2018-09-30");
+        assertRow(ds.rows.get(1), "Alpha Test", "Review", 0.5, "2018-09-30");
+        assertRow(ds.rows.get(2), "Backend Development", "Doing", 4.0, "2018-09-30");
+        assertRow(ds.rows.get(3), "Backend Development", "Review", 0.0, "2018-09-30");
+    }
+
+    @Test
+    public void getWipChartDataSet_whenTimelineRangeContainsDataSetDateRange_thenReturnsWholeDataSet() {
+        String projectKey = "TASKB";
+        String issueLevel = LEVEL_SUBTASKS;
+        
+        new TestEnvConfigurator(projectKey)
+            .withTimelineReferenceDate("2018-09-25")
+            .withTimelineStartDate("2018-09-23")
+            .withTimelineDeliveryDate("2018-10-06")
+            .withTimelineBaselineDate("2018-09-25")
+            .withDemands()
+            .withFeatures()
+            .withSubtasks(
+                    row("Alpha Test").withStatus("Doing").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-25").withWIP(6),
+                    row("Backend Development").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-26").withWIP(8),
+                    row("Backend Development").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-27").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-27").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-27").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-27").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-28").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-28").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-28").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-28").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-29").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-29").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-29").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-29").withWIP(1),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-30").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-30").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-01").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-01").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-01").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-01").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-02").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-02").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-02").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-02").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-03").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-03").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-03").withWIP(3),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-04").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-04").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-05").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-05").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-05").withWIP(5),
+                    row("Backend Development").withStatus("Review").at("2018-10-05").withWIP(0))
+            .configure();
+
+        WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+
+        assertThat(ds.rows.size(), is(8));
+        assertRow(ds.rows.get(0), "Alpha Test", "Doing", 0.0, "2018-09-23");
+        assertRow(ds.rows.get(1), "Alpha Test", "Review", 0.0, "2018-09-23");
+        assertRow(ds.rows.get(2), "Backend Development", "Doing", 5.2, "2018-09-23");
+        assertRow(ds.rows.get(3), "Backend Development", "Review", 1.0, "2018-09-23");
+        assertRow(ds.rows.get(4), "Alpha Test", "Doing", 1.0, "2018-09-30");
+        assertRow(ds.rows.get(5), "Alpha Test", "Review", 0.5, "2018-09-30");
+        assertRow(ds.rows.get(6), "Backend Development", "Doing", 4.0, "2018-09-30");
+        assertRow(ds.rows.get(7), "Backend Development", "Review", 0.0, "2018-09-30");
+    }
+
+    @Test
+    public void getWipChartDataSet_whenTimelineRangeWithinDataSetRange_thenReturnsFilteredDataSet() {
+        String projectKey = "TASKB";
+        String issueLevel = LEVEL_SUBTASKS;
+        
+        new TestEnvConfigurator(projectKey)
+            .withTimelineReferenceDate("2018-09-25")
+            .withTimelineStartDate("2018-09-30")
+            .withTimelineDeliveryDate("2018-10-06")
+            .withTimelineBaselineDate("2018-09-30")
+            .withDemands()
+            .withFeatures()
+            .withSubtasks(
+                    row("Alpha Test").withStatus("Doing").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-25").withWIP(6),
+                    row("Backend Development").withStatus("Review").at("2018-09-25").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-26").withWIP(8),
+                    row("Backend Development").withStatus("Review").at("2018-09-26").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-27").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-27").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-27").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-27").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-28").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-28").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-28").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-28").withWIP(2),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-29").withWIP(0),
+                    row("Alpha Test").withStatus("Review").at("2018-09-29").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-29").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-29").withWIP(1),
+                    row("Alpha Test").withStatus("Doing").at("2018-09-30").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-09-30").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-30").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-01").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-01").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-01").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-09-01").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-02").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-02").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-02").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-02").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-03").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-03").withWIP(1),
+                    row("Backend Development").withStatus("Doing").at("2018-10-03").withWIP(3),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-04").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-04").withWIP(4),
+                    row("Backend Development").withStatus("Review").at("2018-10-04").withWIP(0),
+                    row("Alpha Test").withStatus("Doing").at("2018-10-05").withWIP(1),
+                    row("Alpha Test").withStatus("Review").at("2018-10-05").withWIP(0),
+                    row("Backend Development").withStatus("Doing").at("2018-10-05").withWIP(5),
+                    row("Backend Development").withStatus("Review").at("2018-10-05").withWIP(0))
+            .configure();
+
+        WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+
+        assertThat(ds.rows.size(), is(4));
+        assertRow(ds.rows.get(0), "Alpha Test", "Doing", 1.0, "2018-09-30");
+        assertRow(ds.rows.get(1), "Alpha Test", "Review", 0.5, "2018-09-30");
+        assertRow(ds.rows.get(2), "Backend Development", "Doing", 4.0, "2018-09-30");
+        assertRow(ds.rows.get(3), "Backend Development", "Review", 0.0, "2018-09-30");
+    }
+
+    @Test
+    public void getWipChartDataSet_whenTimelineDatesNotSet_thenNotFiltering() {
+        String projectKey = "TASKB";
+        String issueLevel = LEVEL_DEMANDS;
+        
+        new TestEnvConfigurator(projectKey)
+            .withTimelineReferenceDate("2018-09-25")
+            .withDemands(
+                    row("Demand").withStatus("Development").at("2018-09-25").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-26").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-27").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-28").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-29").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-30").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-01").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-02").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-03").withWIP(2),
+                    row("Demand").withStatus("Development").at("2018-10-04").withWIP(2),
+                    row("Demand").withStatus("Development").at("2018-10-05").withWIP(2))
+            .withFeatures()
+            .withSubtasks()
+            .configure();
+
+        WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+
+        assertThat(ds.rows.size(), is(2));
+        assertRow(ds.rows.get(0), "Demand", "Development", 1.0, "2018-09-23");
+        assertRow(ds.rows.get(1), "Demand", "Development", 1.5, "2018-09-30");
+    }
+
+    @Test
+    public void getWipChartDataSet_whenDataSetWithoutSubtasksAndRequestingFeatures_thenReturnsSuccessfully() {
+        String projectKey = "TASKB";
+        String issueLevel = LEVEL_FEATURES;
+        
+        new TestEnvConfigurator(projectKey)
+            .withTimelineReferenceDate("2018-09-25")
+            .withTimelineStartDate("2018-09-25")
+            .withTimelineDeliveryDate("2018-10-05")
+            .withTimelineBaselineDate("2018-09-25")
+            .withDemands(
+                    row("Demand").withStatus("Development").at("2018-09-25").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-26").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-27").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-28").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-29").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-30").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-01").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-02").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-03").withWIP(2),
+                    row("Demand").withStatus("Development").at("2018-10-04").withWIP(2),
+                    row("Demand").withStatus("Development").at("2018-10-05").withWIP(2))
+            .withFeatures(
+                    row("Bug").withStatus("Development").at("2018-09-25").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-25").withWIP(2),
+                    row("Bug").withStatus("Development").at("2018-09-26").withWIP(1),
+                    row("Task").withStatus("Development").at("2018-09-26").withWIP(4),
+                    row("Bug").withStatus("Development").at("2018-09-27").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-27").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-09-28").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-28").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-09-29").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-29").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-09-30").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-30").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-01").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-01").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-02").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-02").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-03").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-03").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-04").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-04").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-05").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-05").withWIP(1))
+            .withSubtasks()
+            .configure();
+
+        final WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+
+        assertThat(ds.rows.size(), is(4));
+        assertRow(ds.rows.get(0), "Bug", "Development", 0.2, "2018-09-23");
+        assertRow(ds.rows.get(1), "Task", "Development", 1.8, "2018-09-23");
+        assertRow(ds.rows.get(2), "Bug", "Development", 0.0, "2018-09-30");
+        assertRow(ds.rows.get(3), "Task", "Development", 1.0, "2018-09-30");
+    }
+    
+    @Test
+    public void getDataSet_whenRequestingFeaturesAndDataSetOnlyHasDemands_thenReturnsEmptyDataSet() {
+        String projectKey = "TASKB";
+        String issueLevel = LEVEL_FEATURES;
+        
+        new TestEnvConfigurator(projectKey)
+            .withTimelineReferenceDate("2018-09-25")
+            .withTimelineStartDate("2018-09-25")
+            .withTimelineDeliveryDate("2018-09-28")
+            .withTimelineBaselineDate("2018-09-25")
+            .withDemands(
+                    row("Demand").withStatus("Development").at("2018-09-25").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-26").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-27").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-28").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-29").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-09-30").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-01").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-02").withWIP(1),
+                    row("Demand").withStatus("Development").at("2018-10-03").withWIP(2),
+                    row("Demand").withStatus("Development").at("2018-10-04").withWIP(2),
+                    row("Demand").withStatus("Development").at("2018-10-05").withWIP(2))
+            .configure();
 
         final WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
 
         assertThat(ds.rows.size(), is(0));
     }
+    @Test
+    public void getWipChartDataSet_whenTimelineStartDateWithinAndEndDateNotSet_thenFiltersBeginOnly() {
+        String projectKey = "TASKB";
+        String issueLevel = LEVEL_FEATURES;
+        
+        new TestEnvConfigurator(projectKey)
+            .withTimelineReferenceDate("2018-09-25")
+            .withTimelineStartDate("2018-09-30")
+            .withTimelineBaselineDate("2018-09-25")
+            .withFeatures(
+                    row("Bug").withStatus("Development").at("2018-09-25").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-25").withWIP(2),
+                    row("Bug").withStatus("Development").at("2018-09-26").withWIP(1),
+                    row("Task").withStatus("Development").at("2018-09-26").withWIP(4),
+                    row("Bug").withStatus("Development").at("2018-09-27").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-27").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-09-28").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-28").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-09-29").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-29").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-09-30").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-09-30").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-01").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-01").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-02").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-02").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-03").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-03").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-04").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-04").withWIP(1),
+                    row("Bug").withStatus("Development").at("2018-10-05").withWIP(0),
+                    row("Task").withStatus("Development").at("2018-10-05").withWIP(1))
+            .configure();
 
-    private void assertRow(WipDataPoint wipDataPoint, String issueType, String issueStatus, Long wipCount, String date) {
-        assertThat(wipDataPoint.type, is(issueType));
-        assertThat(wipDataPoint.status, is(issueStatus));
-        assertThat(wipDataPoint.date, is(Date.from(parseDateTime(date).toInstant())));
-        assertThat(wipDataPoint.count, is(wipCount));
+        final WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+
+        assertThat(ds.rows.size(), is(2));
+        assertRow(ds.rows.get(0), "Bug", "Development", 0.0, "2018-09-30");
+        assertRow(ds.rows.get(1), "Task", "Development", 1.0, "2018-09-30");
+    }
+
+    @Test
+    public void getWipChartDataSet_whenTimelineDatesNotSetDatasetEmpty_thenReturnsEmptyDataSet() {
+        String projectKey = "TASKB";
+        String issueLevel = LEVEL_ALL;
+
+        new TestEnvConfigurator(projectKey)
+            .withTimelineReferenceDate("2018-09-25")
+            .configure();
+
+        final WipChartDataSet ds = subject.getDataSet(projectKey, issueLevel, ZONE_ID);
+
+        assertThat(ds.rows.size(), is(0));
+    }
+    
+    private void assertRow(WipDataPoint actual, String expectedIssueType, String expectedIssueStatus, Double expectedWIPAverage, String date) {
+        assertThat(actual.issueType, is(expectedIssueType));
+        assertThat(actual.issueStatus, is(expectedIssueStatus));
+        final ZonedDateTime expectedDate = parseDateTime(date);
+        assertThat(DayOfWeek.SUNDAY, is(expectedDate.getDayOfWeek()));
+        assertThat(actual.date, is(Date.from(expectedDate.toInstant())));
+        assertThat(actual.average, is(expectedWIPAverage));
+    }
+    
+    private WipRowBuilder row(String issueType) {
+        WipRowBuilder rowBuilder = new WipRowBuilder(issueType);
+        return rowBuilder;
     }
 
     private class TestEnvConfigurator {
         private String projectKey;
-        private WipDataSet demands = new WipDataSet(TYPE_DEMAND, new LinkedList<>());
-        private WipDataSet features = new WipDataSet(TYPE_FEATURES, new LinkedList<>());
-        private WipDataSet subtasks  = new WipDataSet(TYPE_SUBTASKS, new LinkedList<>());
+        private Map<String, WipDataSetBuilder> dsBuilders;
         private Optional<LocalDate> startDate = Optional.empty();
         private Optional<LocalDate> deliveryDate = Optional.empty();
         private Optional<LocalDate> baselineDate = Optional.empty();
+        private LocalDate referenceDate;
 
         private TestEnvConfigurator(String projectKey) {
-            this.projectKey = projectKey; 
+            this.projectKey = projectKey;
+            dsBuilders = new HashMap<>();
+            dsBuilders.put(LEVEL_DEMANDS, new WipDataSetBuilder(LEVEL_DEMANDS));
+            dsBuilders.put(LEVEL_FEATURES, new WipDataSetBuilder(LEVEL_FEATURES));
+            dsBuilders.put(LEVEL_SUBTASKS, new WipDataSetBuilder(LEVEL_SUBTASKS));
         }
-
-        private TestEnvConfigurator withDemands() {
-            demands.rows.add(new WipRow(parseDateTime("2017-09-25"), "Demand", "Doing", 0L));
-            demands.rows.add(new WipRow(parseDateTime("2017-09-25"), "OS", "Doing", 0L));
-            demands.rows.add(new WipRow(parseDateTime("2017-09-26"), "Demand", "Doing", 1L));
-            demands.rows.add(new WipRow(parseDateTime("2017-09-26"), "OS", "Doing", 1L));
-            demands.rows.add(new WipRow(parseDateTime("2017-09-27"), "Demand", "Doing", 0L));
-            demands.rows.add(new WipRow(parseDateTime("2017-09-27"), "OS", "Doing", 1L));
-
-            return this;
-        }
-
-        private TestEnvConfigurator withFeatures() {
-            features.rows.add(new WipRow(parseDateTime("2017-09-25"), "Feature", "Doing", 0L));
-            features.rows.add(new WipRow(parseDateTime("2017-09-26"), "Feature", "Doing", 1L));
-
-            return this;
-        }
-
-        private TestEnvConfigurator withSubtasks() {
-            subtasks.rows.add(new WipRow(parseDateTime("2017-09-25"), "Dev", "Doing", 0L));
-            subtasks.rows.add(new WipRow(parseDateTime("2017-09-26"), "Dev", "Doing", 1L));
-            subtasks.rows.add(new WipRow(parseDateTime("2017-09-27"), "Dev", "Doing", 2L));
-            subtasks.rows.add(new WipRow(parseDateTime("2017-09-28"), "Dev", "Doing", 1L));
-
+        
+        private TestEnvConfigurator withDemands(WipRowBuilder ... rowBuilders) {
+            WipDataSetBuilder demandsBuilder = dsBuilders.get(LEVEL_DEMANDS);
+            demandsBuilder.addRowBuilders(Arrays.asList(rowBuilders));
             return this;
         }
         
-        private TestEnvConfigurator withTimelineWithinRange() {
-            this.startDate = Optional.of(parse("2017-09-25"));
-            this.deliveryDate = Optional.of(parse("2017-09-28"));
-            this.baselineDate = Optional.of(parse("2017-09-25"));
-            
+        private TestEnvConfigurator withFeatures(WipRowBuilder ... rowBuilders) {
+            WipDataSetBuilder demandsBuilder = dsBuilders.get(LEVEL_FEATURES);
+            demandsBuilder.addRowBuilders(Arrays.asList(rowBuilders));
             return this;
         }
         
-        private TestEnvConfigurator withShorterTimeline() {
-            this.startDate = Optional.of(parse("2017-09-20"));
-            this.deliveryDate = Optional.of(parse("2017-09-23"));
-            this.baselineDate = Optional.of(parse("2017-09-20"));
-            
+        private TestEnvConfigurator withSubtasks(WipRowBuilder ... rowBuilders) {
+            WipDataSetBuilder demandsBuilder = dsBuilders.get(LEVEL_SUBTASKS);
+            demandsBuilder.addRowBuilders(Arrays.asList(rowBuilders));
             return this;
         }
         
-        private TestEnvConfigurator withLongerTimeline() {
-            this.startDate = Optional.of(parse("2017-09-29"));
-            this.deliveryDate = Optional.of(parse("2017-09-30"));
-            this.baselineDate = Optional.of(parse("2017-09-29"));
-            
+        private TestEnvConfigurator withTimelineStartDate(String startDate) {
+            this.startDate = Optional.of(parse(startDate));
             return this;
         }
         
+        private TestEnvConfigurator withTimelineDeliveryDate(String deliveryDate) {
+            this.deliveryDate = Optional.of(parse(deliveryDate));
+            return this;
+        }
+        
+        private TestEnvConfigurator withTimelineBaselineDate(String baselineDate) {
+            this.baselineDate = Optional.of(parse(baselineDate));
+            return this;
+        }
+        
+        private TestEnvConfigurator withTimelineReferenceDate(String referenceDate) {
+            this.referenceDate = parse(referenceDate);
+            return this;
+        }
 
         private void configure() {
+            if (referenceDate == null)
+                throw new RuntimeException("Timeline reference date must be set!");
+            
+            List<WipDataSet> dataSets = Arrays.asList(
+                    dsBuilders.get(LEVEL_DEMANDS).build(), 
+                    dsBuilders.get(LEVEL_FEATURES).build(), 
+                    dsBuilders.get(LEVEL_SUBTASKS).build());
             when(dataRepository.getFirstDate(projectKey)).thenReturn(startDate);
-            mockWipKpiService();
+            mockWipKpiService(dataSets);
         }
         
-        private void mockWipKpiService() {
-            List<WipDataSet> dataSets = Arrays.asList(demands, features, subtasks);
+        private void mockWipKpiService(List<WipDataSet> dataSets) {
             ProjectFilterConfiguration projectFilter = createProjectFilter();
             final FollowUpSnapshot snapshot = mockFollowUpSnapshot(projectFilter);
             when(wipKpiService.getData(snapshot.getData())).thenReturn(dataSets);
@@ -270,10 +854,68 @@ public class WipKPIDataProviderTest {
         }
 
         private FollowUpTimeline createCustomTimeline(ProjectFilterConfiguration projectFilter) {
-            LocalDate referenceDate = LocalDate.parse("2017-09-25");
 
             FollowUpTimeline timeline = FollowUpTimeline.build(referenceDate, projectFilter, dataRepository);
             return timeline;
+        }
+    }
+    
+    private class WipDataSetBuilder {
+        private String issueLevel;
+        private List<WipRowBuilder> rowBuilders = new LinkedList<>();
+        
+        private WipDataSetBuilder(String issueLevel) {
+            this.issueLevel = issueLevel;
+        }
+        
+        private void addRowBuilders(List<WipRowBuilder> rowBuilders) {
+            this.rowBuilders = rowBuilders;
+        }
+        
+        private WipDataSet build() {
+            List<WipRow> rows = rowBuilders.stream()
+                    .map(b -> b.build()).collect(Collectors.toList());
+            WipDataSet dataset = new WipDataSet(issueLevel, rows);
+            return dataset;
+        }
+    }
+    
+    private class WipRowBuilder {
+        private ZonedDateTime date;
+        private String issueType;
+        private String issueStatus;
+        private Long wip;
+        
+        private WipRowBuilder(String issueType) {
+            this.issueType = issueType;
+        }
+
+        private WipRowBuilder withStatus(String issueStatus) {
+            this.issueStatus = issueStatus;
+            return this;
+        }
+
+        private WipRowBuilder at(String date) {
+            this.date = parseDateTime(date);
+            return this;
+        }
+        
+        private WipRowBuilder withWIP(long wip) {
+            this.wip = wip;
+            return this;
+        }
+        
+        private WipRow build() {
+            if (date == null)
+                throw new RuntimeException("Date required!");
+            if (issueType == null)
+                throw new RuntimeException("Issue Type required!");
+            if (issueStatus == null)
+                throw new RuntimeException("Issue Status required!");
+            if (wip == null)
+                throw new RuntimeException("WIP required!");
+            
+            return new WipRow(date, issueType, issueStatus, wip);
         }
     }
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -138,9 +138,9 @@ jira.statusPriorityOrder.tasks=Cancelled,Done,QAing,To QA,Feature Reviewing,To F
 jira.statusPriorityOrder.subtasks=Cancelled,Done,Reviewing,To Review,Doing,To Do,Open
 
 # Status Counting On Wip
-jira.statusCountingOnWip.demands=UATing,To UAT,Doing
-jira.statusCountingOnWip.tasks=QAing,To QA,Feature Reviewing,To Feature Review,Alpha Testing,To Alpha Test,Doing
-jira.statusCountingOnWip.subtasks=Reviewing,To Review,Doing
+jira.statusCountingOnWip.demands=Doing,To UAT,UATing
+jira.statusCountingOnWip.tasks=Doing,To Alpha Test,Alpha Testing,To Feature Review,Feature Reviewing,To QA,QAing
+jira.statusCountingOnWip.subtasks=Doing,To Review,Reviewing
 
 # Status Counting On Throughput
 jira.finalStatuses.demands=Cancelled,Done


### PR DESCRIPTION
###  Changes:

#### Back-end
- Created WeekRangeNormalizer to adjust the data's date range to start on a Sunday and to end on a Saturday;
- WIP and Througput KPI Data Providers adjusted to provide weekly based data;
- Fixed status order on application-test.properties to correctly display on dashboard;

#### Front-end
- Added Highcharts lib;
- Created WIP and Throughput charts using Highcharts and integrated them to the current dc.js timeline;
