### PR TITLE
[TOOLS-2500] Replacing filter location for IssueKpi

### DIFF
--- a/kpi-parent/kpi-cycle-time/src/main/java/objective/taskboard/followup/kpi/cycletime/CycleTimeDataProvider.java
+++ b/kpi-parent/kpi-cycle-time/src/main/java/objective/taskboard/followup/kpi/cycletime/CycleTimeDataProvider.java
@@ -31,7 +31,7 @@ public class CycleTimeDataProvider {
     }
 
     public List<CycleTimeKpi> getDataSet(String projectKey, KpiLevel kpiLevel, ZoneId timezone) {
-        List<IssueKpi> issues = kpiService.getIssuesFromCurrentState(projectKey, timezone, kpiLevel);
+        List<IssueKpi> issues = kpiService.getIssuesFromCurrentStateWithDefaultFilters(projectKey, timezone, kpiLevel);
         Map<KpiLevel, Set<String>> cycleStatusesByLevel = cycleTimeProperties.getCycleTime().toMap();
         CycleTimeKpiFactory factory = new CycleTimeKpiFactory(cycleStatusesByLevel, colorService);
         return issues.stream()

--- a/kpi-parent/kpi-lead-time/src/main/java/objective/taskboard/followup/kpi/leadtime/LeadTimeKpiDataProvider.java
+++ b/kpi-parent/kpi-lead-time/src/main/java/objective/taskboard/followup/kpi/leadtime/LeadTimeKpiDataProvider.java
@@ -31,7 +31,7 @@ public class LeadTimeKpiDataProvider {
     }
 
     public List<LeadTimeKpi> getDataSet(String projectKey, KpiLevel kpiLevel, ZoneId timezone) {
-        List<IssueKpi> issues = kpiDataService.getIssuesFromCurrentState(projectKey, timezone, kpiLevel);
+        List<IssueKpi> issues = kpiDataService.getIssuesFromCurrentStateWithDefaultFilters(projectKey, timezone, kpiLevel);
         LeadTimeKpiFactory factory = new LeadTimeKpiFactory(leadStatusesByLevel);
         return issues.stream()
                 .filter(i -> i.hasCompletedCycle(leadStatusesByLevel.get(i.getLevel())))

--- a/kpi-parent/kpi-testutils/src/main/java/objective/taskboard/followup/kpi/IssueKpiAsserter.java
+++ b/kpi-parent/kpi-testutils/src/main/java/objective/taskboard/followup/kpi/IssueKpiAsserter.java
@@ -102,6 +102,11 @@ public class IssueKpiAsserter<T> {
         Assertions.assertThat(subject.getIssueTypeName()).isEqualTo(type);
         return this;
     }
+    
+    public IssueKpiAsserter<T> hasLastTransitedStatus(String status) {
+        Assertions.assertThat(subject.getLastTransitedStatus()).hasValue(status);
+        return this;
+    }
 
     public class SubtaskChecker {
         private List<ZonedWorklog> childrenWorklogs;

--- a/kpi-parent/kpi-testutils/src/main/java/objective/taskboard/followup/kpi/StatusTransitionAsserter.java
+++ b/kpi-parent/kpi-testutils/src/main/java/objective/taskboard/followup/kpi/StatusTransitionAsserter.java
@@ -4,7 +4,6 @@ import static objective.taskboard.utils.DateTimeUtils.parseDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -46,13 +45,36 @@ public class StatusTransitionAsserter {
         return new DateChecker(date);
     }
 
-    public DatedStatusTransition atDate(String date) {
-        return new DatedStatusTransition(parseDateTime(date));
+    public DatedStatusTransitionAsserter atDate(String date) {
+        return new DatedStatusTransitionAsserter(parseDateTime(date));
     }
 
     public StatusTransitionNodeAsserter status(String statusName) {
         StatusTransition statusTransition = statusMap.get(statusName);
         return new StatusTransitionNodeAsserter(statusTransition);
+    }
+    
+    public StatusChecker<DatedStatusTransition> lastTransitionStatus() {
+        return new StatusChecker<DatedStatusTransition>(status.lastTransitedStatus());
+    }
+    
+    public class StatusChecker<T extends StatusTransition> {
+
+        private Optional<T> statusToBeChecked;
+
+        public StatusChecker(Optional<T> statusToBeChecked) {
+            this.statusToBeChecked = statusToBeChecked;
+        }
+
+        public StatusChecker<T> is(String statusName) {
+            Assertions.assertThat(statusToBeChecked).hasValueSatisfying(
+                    status -> Assertions.assertThat(status.getStatusName()).isEqualTo(statusName)
+            );
+            return this;
+        }
+        
+        
+        
     }
 
     public class DateChecker {
@@ -76,10 +98,10 @@ public class StatusTransitionAsserter {
 
     }
 
-    public class DatedStatusTransition {
+    public class DatedStatusTransitionAsserter {
         private ZonedDateTime date;
 
-        private DatedStatusTransition(ZonedDateTime date) {
+        private DatedStatusTransitionAsserter(ZonedDateTime date) {
             this.date = date;
         }
 
@@ -90,15 +112,15 @@ public class StatusTransitionAsserter {
 
         public StatusTransitionAsserter isStatus(String status) {
             Optional<StatusTransition> givenDate = givenDate();
-            assertTrue(givenDate.isPresent());
-            assertTrue(givenDate.get().isStatus(status));
+            Assertions.assertThat(givenDate).hasValueSatisfying(
+                    statusTransition -> Assertions.assertThat(statusTransition.isStatus(status)).isTrue() 
+            );
 
             return StatusTransitionAsserter.this;
         }
 
         public Optional<StatusTransition> givenDate() {
-            Optional<StatusTransition> givenDate = StatusTransitionAsserter.this.status.givenDate(date);
-            return givenDate;
+            return status.givenDate(date);
         }
 
     }
@@ -144,4 +166,5 @@ public class StatusTransitionAsserter {
             return parseDateTime(date, "00:00:00", timezone);
         }
     }
+
 }

--- a/kpi-parent/kpi-testutils/src/main/java/objective/taskboard/followup/kpi/services/IssueKpiTestRepository.java
+++ b/kpi-parent/kpi-testutils/src/main/java/objective/taskboard/followup/kpi/services/IssueKpiTestRepository.java
@@ -36,15 +36,15 @@ public class IssueKpiTestRepository {
         return issues;
     }
     
-    Map<String,Map<KpiLevel,List<IssueKpi>>> getIssuesByProject(){
+    Map<String,List<IssueKpi>> getIssuesByProject(){
         if(issuesKpi == null)
             buildAll();
         
         Map<String, List<IssueKpiMetadata>> metadataByProject = issuesKpi.stream().collect(Collectors.groupingBy(IssueKpiMetadata::getProject));
-        Map<String,Map<KpiLevel,List<IssueKpi>>> issuesByProject = new LinkedHashMap<>();
+        Map<String,List<IssueKpi>> issuesByProject = new LinkedHashMap<>();
         for (Entry<String,List<IssueKpiMetadata>> entry : metadataByProject.entrySet()) {
-            Map<KpiLevel,List<IssueKpi>> issuesKpiByProjectAndLevel = entry.getValue().stream().map(IssueKpiMetadata::getIssue).collect(Collectors.groupingBy(IssueKpi::getLevel));
-            issuesByProject.put(entry.getKey(), issuesKpiByProjectAndLevel);
+            List<IssueKpi> issuesKpiByProject = entry.getValue().stream().map(IssueKpiMetadata::getIssue).collect(Collectors.toList());
+            issuesByProject.put(entry.getKey(), issuesKpiByProject);
         }
         return issuesByProject;
     }

--- a/kpi-parent/kpi-testutils/src/main/java/objective/taskboard/followup/kpi/services/JiraPropertiesMocker.java
+++ b/kpi-parent/kpi-testutils/src/main/java/objective/taskboard/followup/kpi/services/JiraPropertiesMocker.java
@@ -197,6 +197,10 @@ public class JiraPropertiesMocker {
             this.statusesNames = Arrays.asList(statuses);
             return this;
         }
+        
+        public List<String> statusesExcluded(){
+            return statusesNames;
+        }
 
         public JiraPropertiesMocker eof() {
             return JiraPropertiesMocker.this;

--- a/kpi-parent/kpi-testutils/src/test/java/objective/taskboard/followup/kpi/IssueKpiTest.java
+++ b/kpi-parent/kpi-testutils/src/test/java/objective/taskboard/followup/kpi/IssueKpiTest.java
@@ -1059,6 +1059,114 @@ public class IssueKpiTest {
                     .hasType("Demand")
                     .hasEffortSumFromChildrenWithSubtaskTypeName(0.0, "Foo");
     }
+    
+    @Test
+    public void getLastTransitedStatus_happyDay() {
+        dsl()
+        .environment()
+            .givenSubtask("PROJ-01")
+                .emptyType()
+                .project("PROJ")
+                .withTransitions()
+                    .status("Open").date("2020-01-01")
+                    .status("To Do").date("2020-01-02")
+                    .status("Doing").date("2020-01-03")
+                    .status("To Review").date("2020-01-06")
+                    .status("Reviewing").date("2020-01-07")
+                    .status("Done").date("2020-01-08")
+                .eoT()
+            .eoI()
+        .then()
+            .assertThat()
+                .issueKpi("PROJ-01").hasLastTransitedStatus("Done");
+    }
+    
+    @Test
+    public void getLastTransitedStatus_skippingStatus() {
+        dsl()
+        .environment()
+            .givenSubtask("PROJ-01")
+                .emptyType()
+                .project("PROJ")
+                .withTransitions()
+                    .status("Open").date("2020-01-01")
+                    .status("To Do").noDate()
+                    .status("Doing").date("2020-01-02")
+                    .status("To Review").noDate()
+                    .status("Reviewing").noDate()
+                    .status("Done").date("2020-01-08")
+                .eoT()
+            .eoI()
+        .then()
+            .assertThat()
+                .issueKpi("PROJ-01").hasLastTransitedStatus("Done");
+    }
+    
+    @Test
+    public void getLastTransitedStatus_issueInProgress() {
+        dsl()
+        .environment()
+            .givenSubtask("PROJ-01")
+                .emptyType()
+                .project("PROJ")
+                .withTransitions()
+                    .status("Open").date("2020-01-01")
+                    .status("To Do").noDate()
+                    .status("Doing").date("2020-01-02")
+                    .status("To Review").noDate()
+                    .status("Reviewing").noDate()
+                    .status("Done").noDate()
+                .eoT()
+            .eoI()
+        .then()
+            .assertThat()
+                .issueKpi("PROJ-01").hasLastTransitedStatus("Doing");
+    }
+    
+    @Test
+    public void getLastTransitedStatus_issueIOpen() {
+        dsl()
+        .environment()
+            .givenSubtask("PROJ-01")
+                .emptyType()
+                .project("PROJ")
+                .withTransitions()
+                    .status("Open").date("2020-01-01")
+                    .status("To Do").noDate()
+                    .status("Doing").noDate()
+                    .status("To Review").noDate()
+                    .status("Reviewing").noDate()
+                    .status("Done").noDate()
+                .eoT()
+            .eoI()
+        .then()
+            .assertThat()
+                .issueKpi("PROJ-01").hasLastTransitedStatus("Open");
+    }
+    
+    @Test
+    public void getLastTransitedStatus_idisregardingWorklogs() {
+        dsl()
+        .environment()
+            .givenSubtask("PROJ-01")
+                .emptyType()
+                .project("PROJ")
+                .withTransitions()
+                    .status("Open").date("2020-01-01")
+                    .status("To Do").noDate()
+                    .status("Doing").date("2020-01-06")
+                    .status("To Review").noDate()
+                    .status("Reviewing").noDate()
+                    .status("Done").date("2020-01-08")
+                .eoT()
+                .worklogs()
+                    .at("2020-01-07").timeSpentInHours(1.0)
+                .eoW()
+            .eoI()
+        .then()
+            .assertThat()
+                .issueKpi("PROJ-01").hasLastTransitedStatus("Done");
+    }
 
     private DSLKpi dsl() {
         DSLKpi dsl = new DSLKpi();

--- a/kpi-parent/kpi-testutils/src/test/java/objective/taskboard/followup/kpi/StatusTransitionTest.java
+++ b/kpi-parent/kpi-testutils/src/test/java/objective/taskboard/followup/kpi/StatusTransitionTest.java
@@ -646,6 +646,96 @@ public class StatusTransitionTest {
                 .status("Done").hasEnterDate("2020-01-05")
                 .status("Done").hasNoExitDate();
     }
+    
+    @Test
+    public void getLastTransitedStatus_happyDay() {
+        dsl()
+        .environment()
+            .statusTransition()
+                .status("To Do").date("2020-01-01")
+                .status("Doing").date("2020-01-02")
+                .status("To Review").date("2020-01-03")
+                .status("Reviewing").date("2020-01-04")
+                .status("Done").date("2020-01-05")
+            .eoSt()
+        .then()
+        .assertThat()
+            .statusTransition()
+                .lastTransitionStatus().is("Done");
+    }
+    
+    @Test
+    public void getLastTransitedStatus_skippingStatus() {
+        dsl()
+        .environment()
+            .statusTransition()
+                .status("To Do").date("2020-01-01")
+                .status("Doing").date("2020-01-02")
+                .status("To Review").noDate()
+                .status("Reviewing").noDate()
+                .status("Done").date("2020-01-05")
+            .eoSt()
+        .then()
+        .assertThat()
+            .statusTransition()
+                .lastTransitionStatus().is("Done");
+    }
+    
+    @Test
+    public void getLastTransitedStatus_inProgress() {
+        dsl()
+        .environment()
+            .statusTransition()
+                .status("To Do").date("2020-01-01")
+                .status("Doing").date("2020-01-02")
+                .status("To Review").noDate()
+                .status("Reviewing").noDate()
+                .status("Done").noDate()
+            .eoSt()
+        .then()
+        .assertThat()
+            .statusTransition()
+                .lastTransitionStatus().is("Doing");
+    }
+    
+    @Test
+    public void getLastTransitedStatus_openIssue() {
+        dsl()
+        .environment()
+            .statusTransition()
+                .status("To Do").date("2020-01-01")
+                .status("Doing").noDate()
+                .status("To Review").noDate()
+                .status("Reviewing").noDate()
+                .status("Done").noDate()
+            .eoSt()
+        .then()
+        .assertThat()
+            .statusTransition()
+                .lastTransitionStatus().is("To Do");
+    }
+    
+    @Test
+    public void getLastTransitedStatus_disregardingWorklog() {
+        dsl()
+        .environment()
+            .statusTransition()
+                .status("To Do").date("2020-01-01")
+                .status("Doing").date("2020-01-02")
+                .status("To Review").noDate()
+                .status("Reviewing").noDate()
+                .status("Done").date("2020-01-05")
+                .withWorklogs()
+                    .timeSpent(300)
+                    .withDate("2020-01-04")
+                    .on("Reviewing")
+                .eoW()
+            .eoSt()
+        .then()
+        .assertThat()
+            .statusTransition()
+                .lastTransitionStatus().is("Done");
+    }
 
     private DSLKpi dsl() {
         DSLKpi dsl = new DSLKpi();

--- a/kpi-parent/kpi-testutils/src/test/java/objective/taskboard/followup/kpi/services/KpiDataServiceTest.java
+++ b/kpi-parent/kpi-testutils/src/test/java/objective/taskboard/followup/kpi/services/KpiDataServiceTest.java
@@ -26,6 +26,7 @@ import objective.taskboard.followup.FollowUpSnapshot;
 import objective.taskboard.followup.FollowUpSnapshotService;
 import objective.taskboard.followup.kpi.IssueKpi;
 import objective.taskboard.followup.kpi.KpiLevel;
+import objective.taskboard.followup.kpi.filters.KpiFilterService;
 import objective.taskboard.followup.kpi.services.DSLKpi;
 import objective.taskboard.followup.kpi.services.DSLSimpleBehaviorWithAsserter;
 import objective.taskboard.followup.kpi.services.IssueKpiService;
@@ -415,7 +416,9 @@ public class KpiDataServiceTest {
             IssueKpiService issueKpiService = environment.services().issueKpi().getService();
             FollowUpSnapshotService followupSnapshotService = environment.services().followupSnapshot().getService();
             ProjectService projectService = environment.services().projects().getService();
-            KpiDataService subject = new KpiDataService(issueKpiService, followupSnapshotService, projectService);
+            KpiFilterService filterService = environment.services().filters().getService();
+            
+            KpiDataService subject = new KpiDataService(issueKpiService, followupSnapshotService, projectService, filterService);
             ZoneId timezone = environment.getTimezone();
             
             List<IssueKpi> issues = getIssues(subject, timezone);
@@ -438,7 +441,7 @@ public class KpiDataServiceTest {
 
         @Override
         protected List<IssueKpi> getIssues(KpiDataService subject, ZoneId timezone) {
-            return subject.getIssuesFromCurrentState(projectKey, timezone, level);
+            return subject.getIssuesFromCurrentStateWithDefaultFilters(projectKey, timezone, level);
         }
 
     }
@@ -481,8 +484,9 @@ public class KpiDataServiceTest {
             FollowUpSnapshotService followupSnapshotService = environment.services().followupSnapshot().getService();
             IssueKpiService issueKpiService = environment.services().issueKpi().getService();
             ProjectService projectService = environment.services().projects().getService();
+            KpiFilterService filterService = environment.services().filters().getService();
 
-            KpiDataService subject = new KpiDataService(issueKpiService, followupSnapshotService, projectService); 
+            KpiDataService subject = new KpiDataService(issueKpiService, followupSnapshotService, projectService, filterService); 
             this.asserter = new SnapshotAsserter(projectKey,timezone, environment, getSnapshot(timezone, subject));
         }
 

--- a/kpi-parent/kpi-touch-time/src/test/java/objective/taskboard/followup/kpi/services/FullTouchTimeTest.java
+++ b/kpi-parent/kpi-touch-time/src/test/java/objective/taskboard/followup/kpi/services/FullTouchTimeTest.java
@@ -8,6 +8,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,6 +17,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import objective.taskboard.followup.kpi.IssueKpi;
 import objective.taskboard.followup.kpi.KpiLevel;
+import objective.taskboard.followup.kpi.filters.KpiLevelFilter;
 import objective.taskboard.followup.kpi.properties.KPIProperties;
 import objective.taskboard.followup.kpi.services.DSLKpi;
 import objective.taskboard.followup.kpi.services.DSLSimpleBehaviorWithAsserter;
@@ -647,11 +649,13 @@ public class FullTouchTimeTest {
             IssueKpiDataItemAdapterFactory factory = services.itemAdapterFactory().getComponent();
 
             IssueKpiService subject = new IssueKpiService(issueBufferService, jiraProperties, kpiProperties, clock, factory);
+            List<IssueKpi> issuesFromCurrentState = subject.getIssuesFromCurrentState(project, zoneId);
 
             for (KpiLevel level : KpiLevel.values()) {
-                allIssues.put(level, subject.getIssuesFromCurrentState(project, zoneId, level));
+                List<IssueKpi> issuesFromLevel = issuesFromCurrentState.stream()
+                        .filter(new KpiLevelFilter(level)).collect(Collectors.toList());
+                allIssues.put(level, issuesFromLevel);
             }
-
         }
 
         @Override

--- a/kpis/src/main/java/objective/taskboard/followup/kpi/DatedStatusTransition.java
+++ b/kpis/src/main/java/objective/taskboard/followup/kpi/DatedStatusTransition.java
@@ -95,6 +95,12 @@ public class DatedStatusTransition extends StatusTransition {
         Optional<DatedStatusTransition> nextWithDate = next.flatMap(n -> n.withDate());
         return nextWithDate.map(n -> !n.isProgressingStatus && isSameDate(n)).orElse(false);
     }
+    
+    @Override
+    protected Optional<DatedStatusTransition> lastTransitedStatus() {
+        Optional<DatedStatusTransition> possibleNext = super.lastTransitedStatus(); 
+        return possibleNext.isPresent() ? possibleNext : Optional.of(this);
+    }
 
     @Override
     public Optional<LocalDate> firstDateOnProgressing() {

--- a/kpis/src/main/java/objective/taskboard/followup/kpi/IssueKpi.java
+++ b/kpis/src/main/java/objective/taskboard/followup/kpi/IssueKpi.java
@@ -192,4 +192,9 @@ public class IssueKpi {
                 children.stream().flatMap(IssueKpi::getDecendants)
             );
     }
+
+    public Optional<String> getLastTransitedStatus() {
+        Optional<DatedStatusTransition> lastTransitedStatus = firstStatus.flatMap(StatusTransition::lastTransitedStatus);
+        return lastTransitedStatus.map(StatusTransition::getStatusName);
+    }
 }

--- a/kpis/src/main/java/objective/taskboard/followup/kpi/StatusTransition.java
+++ b/kpis/src/main/java/objective/taskboard/followup/kpi/StatusTransition.java
@@ -152,6 +152,11 @@ public class StatusTransition {
     List<ZonedWorklog> getWorklogs(){
         return this.worklogs;
     }
+    
+    protected Optional<DatedStatusTransition> lastTransitedStatus(){
+        Optional<DatedStatusTransition> nextWithDate = next.flatMap(StatusTransition::withDate);
+        return nextWithDate.flatMap(StatusTransition::lastTransitedStatus);
+    }
 
     public List<ZonedWorklog> collectWorklog() {
         List<ZonedWorklog> allWorklogs = next.map(StatusTransition::collectWorklog).orElseGet(LinkedList::new);

--- a/kpis/src/main/java/objective/taskboard/followup/kpi/filters/KpiFilterService.java
+++ b/kpis/src/main/java/objective/taskboard/followup/kpi/filters/KpiFilterService.java
@@ -1,0 +1,43 @@
+package objective.taskboard.followup.kpi.filters;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import objective.taskboard.followup.kpi.KpiLevel;
+import objective.taskboard.jira.MetadataService;
+import objective.taskboard.jira.properties.JiraProperties;
+
+@Service
+public class KpiFilterService {
+    
+    private MetadataService metadataService;
+    
+    private JiraProperties jiraProperties;
+
+    @Autowired
+    public KpiFilterService(MetadataService metadataService, JiraProperties jiraProperties) {
+        this.metadataService = metadataService;
+        this.jiraProperties = jiraProperties;
+    }
+    
+    public KpiItemFilter getFilterStatusExcludedFromFollowup() {
+        return new StatusExcludedFromFollowupFilter(getStatusesExcluded());
+    }
+    
+    public KpiItemFilter getLevelFilter(KpiLevel level) {
+        return new KpiLevelFilter(level);
+    }
+
+    private List<String> getStatusesExcluded() {
+        return jiraProperties.getFollowup()
+                    .getStatusExcludedFromFollowup()
+                    .stream()
+                    .map(metadataService::getStatusById)
+                    .map(status -> status.name)
+                    .collect(Collectors.toList());
+    }
+
+}

--- a/kpis/src/main/java/objective/taskboard/followup/kpi/filters/KpiItemFilter.java
+++ b/kpis/src/main/java/objective/taskboard/followup/kpi/filters/KpiItemFilter.java
@@ -1,0 +1,13 @@
+package objective.taskboard.followup.kpi.filters;
+
+import java.util.function.Predicate;
+
+import objective.taskboard.followup.kpi.IssueKpi;
+
+public interface KpiItemFilter extends Predicate<IssueKpi>{
+   
+    default KpiItemFilter concat(KpiItemFilter other) {
+        return issue -> test(issue) && other.test(issue);
+    }
+    
+}

--- a/kpis/src/main/java/objective/taskboard/followup/kpi/filters/KpiLevelFilter.java
+++ b/kpis/src/main/java/objective/taskboard/followup/kpi/filters/KpiLevelFilter.java
@@ -1,0 +1,19 @@
+package objective.taskboard.followup.kpi.filters;
+
+import objective.taskboard.followup.kpi.IssueKpi;
+import objective.taskboard.followup.kpi.KpiLevel;
+
+public class KpiLevelFilter implements KpiItemFilter{
+    
+    private KpiLevel level;
+
+    public KpiLevelFilter(KpiLevel level) {
+        this.level = level;
+    }
+
+    @Override
+    public boolean test(IssueKpi issue) {
+        return issue.getLevel().equals(level);
+    }
+    
+}

--- a/kpis/src/main/java/objective/taskboard/followup/kpi/filters/StatusExcludedFromFollowupFilter.java
+++ b/kpis/src/main/java/objective/taskboard/followup/kpi/filters/StatusExcludedFromFollowupFilter.java
@@ -1,0 +1,22 @@
+package objective.taskboard.followup.kpi.filters;
+
+import java.util.List;
+
+import objective.taskboard.followup.kpi.IssueKpi;
+
+public class StatusExcludedFromFollowupFilter implements KpiItemFilter {
+
+    private List<String> statusExcludedFromFollowUp;
+    
+    public StatusExcludedFromFollowupFilter(List<String> statusExcludedFromFollowUp) {
+        this.statusExcludedFromFollowUp = statusExcludedFromFollowUp;
+    }
+
+    @Override
+    public boolean test(IssueKpi issue) {
+        return issue.getLastTransitedStatus().map(
+                status -> !statusExcludedFromFollowUp.contains(status)
+                ).orElse(false);
+    }
+
+}

--- a/kpis/src/main/java/objective/taskboard/followup/kpi/services/KpiDataService.java
+++ b/kpis/src/main/java/objective/taskboard/followup/kpi/services/KpiDataService.java
@@ -4,7 +4,9 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,8 @@ import objective.taskboard.followup.FollowUpSnapshot;
 import objective.taskboard.followup.FollowUpSnapshotService;
 import objective.taskboard.followup.kpi.IssueKpi;
 import objective.taskboard.followup.kpi.KpiLevel;
+import objective.taskboard.followup.kpi.filters.KpiFilterService;
+import objective.taskboard.followup.kpi.filters.KpiItemFilter;
 import objective.taskboard.followup.kpi.filters.ProjectRangeByConfiguration;
 import objective.taskboard.followup.kpi.filters.ProjectTimelineRange;
 import objective.taskboard.followup.kpi.filters.WithinRangeFilter;
@@ -28,20 +32,35 @@ public class KpiDataService {
     private FollowUpSnapshotService followupSnapshotService;
     
     private ProjectService projectService;
+    
+    private KpiFilterService filterService;
 
     @Autowired
-    public KpiDataService(IssueKpiService issueKpiService, FollowUpSnapshotService followupSnapshotService,ProjectService projectService) {
+    public KpiDataService(
+            IssueKpiService issueKpiService, 
+            FollowUpSnapshotService followupSnapshotService,
+            ProjectService projectService, 
+            KpiFilterService filterService) {
         this.issueKpiService = issueKpiService;
         this.followupSnapshotService = followupSnapshotService;
         this.projectService = projectService;
+        this.filterService = filterService;
     }
     
-    public List<IssueKpi> getIssuesFromCurrentState(String projectKey, ZoneId timezone, KpiLevel kpiLevel){
-        return issueKpiService.getIssuesFromCurrentState(projectKey, timezone, kpiLevel);
+    public List<IssueKpi> getIssuesFromCurrentStateWithDefaultFilters(String projectKey, ZoneId timezone, KpiLevel kpiLevel){
+        List<IssueKpi> allIssues = issueKpiService.getIssuesFromCurrentState(projectKey, timezone);
+        return allIssues.stream().filter(getDefaultFilters(kpiLevel)).collect(Collectors.toList());
+    }
+    
+    private Predicate<IssueKpi> getDefaultFilters(KpiLevel level){
+        KpiItemFilter statusFilter = filterService.getFilterStatusExcludedFromFollowup();
+        KpiItemFilter levelFilter = filterService.getLevelFilter(level);
+        
+        return Stream.of(statusFilter,levelFilter).reduce(w -> true, KpiItemFilter::concat);
     }
     
     public List<IssueKpi> getIssuesFromCurrentProjectRange(String projectKey, ZoneId timezone, KpiLevel kpiLevel){
-        List<IssueKpi> allIssues = getIssuesFromCurrentState(projectKey, timezone, kpiLevel);
+        List<IssueKpi> allIssues = getIssuesFromCurrentStateWithDefaultFilters(projectKey, timezone, kpiLevel);
         ProjectFilterConfiguration project =  projectService.getTaskboardProjectOrCry(projectKey);
         ProjectTimelineRange range = new ProjectRangeByConfiguration(project);
         


### PR DESCRIPTION
- Narrowed the responsability of 'IssueKpiService' to only convert Issues and AnalyticSets to IssueKpi
+ Expanded the KpiDataService responsability, to be the one responsible to apply the default issues to all Kpi's
+ Creating structure to receive new filters